### PR TITLE
Implicit unknown if not specified

### DIFF
--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -124,7 +124,6 @@ fn function<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                     (
                         ctx,
                         Type {
-                            // If we couldn't parse the return type, we assume `-> Void`.
                             span: ctx.span(),
                             kind: Resolved(Unknown),
                         },

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -121,13 +121,7 @@ fn function<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                     // Parameter type
                     parse_type(ctx)?
                 } else {
-                    (
-                        ctx,
-                        Type {
-                            span: ctx.span(),
-                            kind: Resolved(Unknown),
-                        },
-                    )
+                    (ctx, Type { span: ctx.span(), kind: Resolved(Unknown) })
                 };
                 ctx = ctx_;
                 params.push((ident, param));


### PR DESCRIPTION
Allows this definition:
```
f :: fn a, b -> * do a + b end
```