### PR TITLE
Even more function declaration helpers

### DIFF
--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -439,6 +439,10 @@ impl TypeChecker {
         match &statement.kind {
             StatementKind::Block { statements } => {
                 // Left this for Gustav
+                if statements.is_empty() {
+                    return Ok(None);
+                }
+
                 let ss = self.stack.len();
                 let rets = self.push_type(Type::Unknown);
                 for stmt in statements.iter() {
@@ -843,7 +847,8 @@ impl TypeChecker {
                 if let Some(actual_ret) = self.statement(body, ctx)? {
                     self.unify(span, ctx, ret, actual_ret)?;
                 } else {
-                    panic!();
+                    let void = self.push_type(Type::Void);
+                    self.unify(span, ctx, ret, void)?;
                 }
 
                 self.stack.truncate(ss);

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -439,19 +439,22 @@ impl TypeChecker {
         match &statement.kind {
             StatementKind::Block { statements } => {
                 // Left this for Gustav
-                if statements.is_empty() {
-                    return Ok(None);
-                }
 
                 let ss = self.stack.len();
                 let rets = self.push_type(Type::Unknown);
+                let mut any_return = false;
                 for stmt in statements.iter() {
                     if let Some(ret) = self.statement(stmt, ctx)? {
                         self.unify(span, ctx, rets, ret)?;
+                        any_return = true;
                     }
                 }
                 self.stack.truncate(ss);
-                Ok(Some(rets))
+                if any_return {
+                    Ok(Some(rets))
+                } else {
+                    Ok(None)
+                }
             }
 
             StatementKind::Ret { value } => Ok(Some(self.expression(value, ctx)?)),

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -799,6 +799,8 @@ mod test {
     test!(expression, fn_implicit_unknown_2: "fn a, b do 1 end" => _);
     test!(expression, fn_implicit_unknown_3: "fn a, b, c do 1 end" => _);
 
+    fail!(expression, fn_invalid_empty_tuple: "fn -> () end" => _);
+
     fail!(expression, fn_self_arg: "fn self: int do 1 end" => _);
 }
 

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -143,8 +143,8 @@ fn function<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
             // Parse return type
             T::Arrow => {
                 ctx = ctx.skip(1);
-                break if let Ok((_ctx, ret)) = parse_type(ctx) {
-                    ctx = _ctx; // assign to outer
+                break if let Ok((ctx_, ret)) = parse_type(ctx) {
+                    ctx = ctx_; // assign to outer
                     ret
                 } else {
                     Type {
@@ -206,9 +206,9 @@ fn parse_precedence<'t>(ctx: Context<'t>, prec: Prec) -> ParseResult<'t, Express
     // Initial value, e.g. a number value, assignable, ...
     let (mut ctx, mut expr) = prefix(ctx)?;
     while prec <= precedence(ctx.token()) {
-        if let Ok((_ctx, _expr)) = infix(ctx, &expr) {
+        if let Ok((ctx_, _expr)) = infix(ctx, &expr) {
             // assign to outer
-            ctx = _ctx;
+            ctx = ctx_;
             expr = _expr;
         } else {
             break;
@@ -508,9 +508,9 @@ fn grouping_or_tuple<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
 
             // Another inner expression.
             _ => {
-                let (_ctx, expr) = expression(ctx)?;
+                let (ctx_, expr) = expression(ctx)?;
                 exprs.push(expr);
-                ctx = _ctx; // assign to outer
+                ctx = ctx_; // assign to outer
 
                 // Not a tuple, until it is.
                 is_tuple |= matches!(ctx.token(), T::Comma);
@@ -553,8 +553,8 @@ fn blob<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
 
                 ctx = expect!(ctx.skip(1), T::Colon, "Expected ':' after field name");
                 // Get the value; `55` in the example above.
-                let (_ctx, expr) = expression(ctx)?;
-                ctx = _ctx; // assign to outer
+                let (ctx_, expr) = expression(ctx)?;
+                ctx = ctx_; // assign to outer
 
                 if !matches!(ctx.token(), T::Comma | T::RightBrace) {
                     raise_syntax_error!(
@@ -602,9 +602,9 @@ fn list<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
 
             // Another one.
             _ => {
-                let (_ctx, expr) = expression(ctx)?;
+                let (ctx_, expr) = expression(ctx)?;
                 exprs.push(expr);
-                ctx = _ctx; // assign to outer
+                ctx = ctx_; // assign to outer
                 ctx = ctx.skip_if(T::Comma);
             }
         }
@@ -652,9 +652,9 @@ fn set_or_dict<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
             // Something that's part of an inner expression.
             _ => {
                 // Parse the expression.
-                let (_ctx, expr) =
+                let (ctx_, expr) =
                     detail_if_error!(expression(ctx), "failed to parse dict or set")?;
-                ctx = _ctx; // assign to outer
+                ctx = ctx_; // assign to outer
                 exprs.push(expr);
 
                 // If a) we know we're a dict or b) the next token is a colon, parse the value of the dict.
@@ -662,8 +662,8 @@ fn set_or_dict<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                 if *is_dict.get_or_insert_with(|| matches!(ctx.token(), T::Colon)) {
                     ctx = expect!(ctx, T::Colon, "Expected ':' for dict pair");
                     // Parse value expression.
-                    let (_ctx, expr) = expression(ctx)?;
-                    ctx = _ctx; // assign to outer
+                    let (ctx_, expr) = expression(ctx)?;
+                    ctx = ctx_; // assign to outer
                     exprs.push(expr);
                 }
 

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -150,7 +150,7 @@ fn function<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                     Type {
                         // If we couldn't parse the return type, we assume `-> Void`.
                         span: ctx.span(),
-                        kind: Resolved(Void),
+                        kind: Resolved(Unknown),
                     }
                 };
             }

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -147,11 +147,7 @@ fn function<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                     ctx = ctx_; // assign to outer
                     ret
                 } else {
-                    Type {
-                        // If we couldn't parse the return type, we assume `-> Void`.
-                        span: ctx.span(),
-                        kind: Resolved(Unknown),
-                    }
+                    Type { span: ctx.span(), kind: Resolved(Unknown) }
                 };
             }
 
@@ -799,7 +795,7 @@ mod test {
     test!(expression, fn_implicit_unknown_2: "fn a, b do 1 end" => _);
     test!(expression, fn_implicit_unknown_3: "fn a, b, c do 1 end" => _);
 
-    fail!(expression, fn_invalid_empty_tuple: "fn -> () end" => _);
+    test!(expression, fn_invalid_empty_tuple: "fn -> () end" => _);
 
     fail!(expression, fn_self_arg: "fn self: int do 1 end" => _);
 }

--- a/tests/blob/self_.sy
+++ b/tests/blob/self_.sy
@@ -3,7 +3,7 @@ A :: blob {
     f: fn -> int,
 }
 
-start :: fn ->
+start :: fn do
     a := A {
         a: 1,
         f: fn -> int do

--- a/tests/blob/self_only_methods.sy
+++ b/tests/blob/self_only_methods.sy
@@ -3,7 +3,7 @@ A :: blob {
     f: fn -> int,
 }
 
-start :: fn ->
+start :: fn do
     a := A {
         a: self.f(),
         f: fn -> int do

--- a/tests/dependencies/out_of_order.sy
+++ b/tests/dependencies/out_of_order.sy
@@ -1,7 +1,7 @@
 a :: b
 b :: 1
 
-start :: fn ->
+start :: fn do
     a <=> 1
     b <=> 1
 end

--- a/tests/hm_typing/empty_function.sy
+++ b/tests/hm_typing/empty_function.sy
@@ -1,0 +1,4 @@
+f :: fn a, b -> int do end
+
+// error: $Mismatch { .. }
+

--- a/tests/hm_typing/empty_function.sy
+++ b/tests/hm_typing/empty_function.sy
@@ -1,4 +1,5 @@
-f :: fn a, b -> int do end
+f :: fn -> int do end
 
+start :: fn do end
 // error: $Mismatch { .. }
 

--- a/tests/import/subdir/exports.sy
+++ b/tests/import/subdir/exports.sy
@@ -1,5 +1,5 @@
 use _numbers
 
 one :: _numbers.one
-start :: fn -> end
+start :: fn do end
 

--- a/tests/import/use_chained.sy
+++ b/tests/import/use_chained.sy
@@ -1,5 +1,5 @@
 use subdir/
 
-start :: fn ->
+start :: fn do
     subdir.one <=> 1
 end

--- a/tests/sylt_std/clear.sy
+++ b/tests/sylt_std/clear.sy
@@ -1,4 +1,4 @@
-start :: fn ->
+start :: fn do
     a := [1, 2, 3, 4]
     clear(a)
     a <=> []

--- a/tests/sylt_std/fold.sy
+++ b/tests/sylt_std/fold.sy
@@ -1,4 +1,4 @@
-start :: fn ->
+start :: fn do
     sum :: [1, 2, 3, 4] -> fold' 0, fn a: int, b:int -> int a + b end
     print' sum
     sum <=> 10

--- a/tests/sylt_std/prepend.sy
+++ b/tests/sylt_std/prepend.sy
@@ -1,4 +1,4 @@
-start :: fn ->
+start :: fn do
     a := [1, 2, 3, 4]
     prepend(a, 0)
     print(a)

--- a/tests/sylt_std/reduce.sy
+++ b/tests/sylt_std/reduce.sy
@@ -1,4 +1,4 @@
-start :: fn ->
+start :: fn do
     add :: fn a: *, b: * -> int a + b end
 
     sum :: reduce' [1, 2, 3, 4], add


### PR DESCRIPTION
- Implicit unknown if not specified
- Drive-by: _ctx -> ctx_
- Special case for empty functions
- Fix argument syntax with implicit return
- Solve implicit return if using ->
