### PR TITLE
unit instead of nil

### DIFF
--- a/sylt-common/src/value.rs
+++ b/sylt-common/src/value.rs
@@ -214,7 +214,7 @@ impl Value {
                 write!(fmt, "<fn #{}>", block)
             }
             Value::ExternFunction(slot) => write!(fmt, "<extern fn {}>", slot),
-            Value::Nil => write!(fmt, "nil"),
+            Value::Nil => write!(fmt, "()"),
         }
     }
 }

--- a/sylt-compiler/src/preamble.lua
+++ b/sylt-compiler/src/preamble.lua
@@ -2,7 +2,7 @@
 -- Built in types
 
 -- THE nil-table
-__NIL = setmetatable( { "nil" }, { __tostring = function() return "nil" end } )
+__NIL = setmetatable( { "nil" }, { __tostring = function() return "()" end } )
 
 __IDENTITY = function(x) return x end
 

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -559,6 +559,9 @@ pub fn parse_type<'t>(ctx: Context<'t>) -> ParseResult<'t, Type> {
     let span = ctx.span();
     let (ctx, kind) = match ctx.token() {
         T::VoidType => (ctx.skip(1), Resolved(Void)),
+        T::LeftParen if matches!(ctx.skip(1).token(), T::RightParen) => {
+            (ctx.skip(2), Resolved(Void))
+        }
         T::IntType => (ctx.skip(1), Resolved(Int)),
         T::FloatType => (ctx.skip(1), Resolved(Float)),
         T::BoolType => (ctx.skip(1), Resolved(Bool)),
@@ -1090,7 +1093,7 @@ mod test {
         test!(parse_type, type_fn_only_ret: "fn -> bool" => Fn{ .. });
         test!(parse_type, type_fn_constraints: "fn<a: A a b + B b b, b: A a a> -> bool" => Fn{ .. });
 
-        test!(parse_type, type_tuple_zero: "()" => Tuple(_));
+        test!(parse_type, type_tuple_zero: "()" => Resolved(RT::Void));
         test!(parse_type, type_tuple_one: "(int,)" => Tuple(_));
         test!(parse_type, type_grouping: "(int)" => Grouping(_));
         test!(parse_type, type_tuple_complex: "(int, str, str,)" => Tuple(_));

--- a/sylt-tokenizer/src/token.rs
+++ b/sylt-tokenizer/src/token.rs
@@ -24,9 +24,6 @@ pub enum Token {
     #[regex(r"[\d]+", |lex| lex.slice().parse())]
     Int(i64),
 
-    #[regex(r"nil")]
-    Nil,
-
     #[regex(r"true|false", |lex| lex.slice().parse(), priority=2)]
     Bool(bool),
 

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -359,7 +359,7 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
         ExpressionKind::Int(i) => write!(dest, "{}", i)?,
         ExpressionKind::Str(s) => write!(dest, "\"{}\"", s)?,
         ExpressionKind::Bool(b) => write!(dest, "{}", b)?,
-        ExpressionKind::Nil => write!(dest, "nil")?,
+        ExpressionKind::Nil => write!(dest, "()")?,
     }
 
     Ok(())

--- a/tests/core/string_conversion.sy
+++ b/tests/core/string_conversion.sy
@@ -53,6 +53,6 @@ start :: fn do
     // Other
     print(d)
     print(pop)
-    as_str(nil) <=> "nil"
+    as_str(()) <=> "()"
 end
 

--- a/tests/if_else/if_else_nested.sy
+++ b/tests/if_else/if_else_nested.sy
@@ -1,4 +1,4 @@
 start :: fn do
-    if false ret nil else ret nil
+    if false ret () else ret ()
 end
 

--- a/tests/looping/nested_statments.sy
+++ b/tests/looping/nested_statments.sy
@@ -1,4 +1,4 @@
 start :: fn do
-    loop true ret nil
+    loop true ret ()
 end
 


### PR DESCRIPTION
- Change the syntax so () -> nil
- Special cases in the test fixed

This doesn't change the internal representation - because the `void`/`()` type
is very helpfull when typechecking and reasoning about the code. This is basically
a reskin - which kinda makes me question why we want this. I don't know if I want it still, since it doesn't solve a single problem - only makes the syntax harder to parse.

Closes #476
