### PR TITLE
Clarify the positive requirement

### DIFF
--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1758,7 +1758,7 @@ impl TypeChecker {
                     span,
                     ctx,
                     TypeError::Exotic,
-                    "Tuples can only be indexed by integer constants"
+                    "Tuples can only be indexed by positive integer constants"
                 );
             }
             Type::List(given) => {


### PR DESCRIPTION
Closes #548

Negative numbers are expressions, a constant and a negation operation, this makes it invalid for
tuple indexing. I clearified the error message since it's a lot more work to do something
smarter that works for all cases.
