### PR TITLE
More error information

### DIFF
--- a/sylt-common/src/error.rs
+++ b/sylt-common/src/error.rs
@@ -77,8 +77,7 @@ pub enum RuntimeError {
 
 #[derive(Debug, Clone)]
 pub struct Helper {
-    pub file: PathBuf,
-    pub span: Span,
+    pub at: Option<(PathBuf, Span)>,
     pub message: String,
 }
 
@@ -272,9 +271,12 @@ impl fmt::Display for Error {
                 if !helpers.is_empty() {
                     // TODO(ed): Might be helpfull to not write all the errors?
                     write!(f, "{}\n", "help:".yellow())?;
-                    for Helper { message, file, span } in helpers.iter() {
+                    for Helper { message, at } in helpers.iter() {
                         write!(f, "{}{}\n", INDENT, message)?;
-                        write_source_span_at(f, file, *span)?;
+                        match at {
+                            Some((file, span)) => write_source_span_at(f, file, *span)?,
+                            None => {}
+                        }
                     }
                 }
                 Ok(())

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -30,7 +30,7 @@ impl<T> Help for TypeResult<T> {
                         message,
                     });
                 }
-                _ => panic!("Cannot help on this error"),
+                _ => panic!("Cannot help on this error since the error is empty"),
             },
         }
         self
@@ -43,7 +43,7 @@ impl<T> Help for TypeResult<T> {
                 Some(Error::TypeError { helpers, .. }) => {
                     helpers.push(Helper { at: None, message });
                 }
-                _ => panic!("Cannot help on this error"),
+                _ => panic!("Cannot help on this error since the error is empty"),
             },
         }
         self

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1550,7 +1550,7 @@ impl TypeChecker {
                                     blob: b_blob.clone(),
                                     field: a_field.clone()
                                 }
-                            )
+                            );
                         };
                     }
 

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1568,7 +1568,7 @@ impl TypeChecker {
                                 )
                             }
                         };
-                        self.unify(span, ctx, *b_ty, a_ty)
+                        self.unify(span, ctx, a_ty, *b_ty)
                             .help_no_span(format!("While checking field .{}", b_field))?;
                     }
                 }


### PR DESCRIPTION
Tries to be descriptive and transparent about `where` things don't match. We now get errors like this:
```
typecheck error: a.sy:8
      A 'str' cannot be a 'int'
      Types don't match
   6 |
   7 | start :: fn do
   8 |     A {
           ^
help:
      While checking dictionary value
      While checking field .q
```

It would be better to point to the actual field - but this cannot be done since types don't have positions in the source code. :(

(We could potentially match the expressions against the blob-fields in the blob-expression, but that might be a bit too... extreem?)