### PR TITLE
Some blob comparison stuff

### DIFF
--- a/sylt-compiler/src/preamble.lua
+++ b/sylt-compiler/src/preamble.lua
@@ -283,7 +283,7 @@ end
 __BLOB_META = { _type = "blob" }
 __BLOB_META.__eq = function(a, b)
     for k, v in pairs(a) do
-        if b[k] == nil or v ~= b[k] then
+        if v ~= b[k] then
             return false
         end
     end

--- a/sylt-machine/src/vm.rs
+++ b/sylt-machine/src/vm.rs
@@ -899,6 +899,16 @@ mod op {
             (Value::List(a), Value::List(b)) => Value::Bool(a == b),
             (Value::Set(a), Value::Set(b)) => Value::Bool(a == b),
             (Value::Dict(a), Value::Dict(b)) => Value::Bool(a == b),
+            (Value::Blob(a), Value::Blob(b)) => Value::Bool(
+                a.borrow().keys().all(|k| b.borrow().contains_key(k))
+                    && b.borrow().keys().all(|k| a.borrow().contains_key(k))
+                    && a.borrow()
+                        .iter()
+                        .all(|(ak, av)| match eq(av, &b.borrow()[ak]) {
+                            Value::Bool(v) => v,
+                            _ => false,
+                        }),
+            ),
             _ => Value::Nil,
         }
     }

--- a/tests/blob/comparison.sy
+++ b/tests/blob/comparison.sy
@@ -1,0 +1,54 @@
+Blob :: blob {
+    a: bool,
+    b: int,
+    c: float,
+}
+
+BlobBlob :: blob {
+    _blob: Blob,
+}
+
+start :: fn do
+    b1 := Blob {
+        a: true,
+        b: 1,
+        c: 0.,
+    }
+
+    b1_eq := Blob {
+        a: true,
+        b: 1,
+        c: 0.,
+    }
+
+    b2 := Blob {
+        a: false,
+        b: 420,
+        c: .0,
+    }
+
+    b1 <=> b1_eq
+    b1 != b2 <=> true
+
+    bb1 := BlobBlob {
+        _blob: b1,
+    }
+
+    bb1_eq := BlobBlob {
+        _blob: b1,
+    }
+
+    bb1 <=> bb1_eq
+
+    bb1_eq2 := BlobBlob {
+        _blob: b1_eq,
+    }
+
+    bb1 <=> bb1_eq2
+
+    bb2 := BlobBlob {
+        _blob: b2,
+    }
+
+    bb1 != bb2 <=> true
+end

--- a/tests/blob/equality.sy
+++ b/tests/blob/equality.sy
@@ -15,6 +15,8 @@ start :: fn do
         c: 0.,
     }
 
+    b1 <=> b1
+
     b1_eq := Blob {
         a: true,
         b: 1,
@@ -37,6 +39,8 @@ start :: fn do
     bb1_eq := BlobBlob {
         _blob: b1,
     }
+
+    bb1 <=> bb1
 
     bb1 <=> bb1_eq
 


### PR DESCRIPTION
- Compare blobs in vm, might work incorrectly when subcomparison returns Value::Nil.
- Add blob comparison test
- Remove comparison with nil from lua preamble, might be wrong of me to do this in this commit since it was a comment in #615.