### PR TITLE
Type the AST

### DIFF
--- a/sylt-common/src/lib.rs
+++ b/sylt-common/src/lib.rs
@@ -8,6 +8,16 @@ pub use error::Error;
 pub use ty::Type;
 pub use value::Value;
 
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Hash)]
+pub struct TyID(pub usize);
+
+impl std::fmt::Display for TyID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let TyID(id) = self;
+        write!(f, "TyID({})", id)
+    }
+}
+
 /// Differentiates lib imports and file imports
 #[derive(Hash, Eq, PartialEq, PartialOrd, Clone, Debug)]
 pub enum FileOrLib {

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -172,7 +172,11 @@ impl Compiler {
         self.extract_globals(&tree);
 
         let mut statements = match dependency::initialization_order(&tree, &self) {
-            Ok(statements) => statements.into_iter().map(|(a, b)| (a.clone(), b)).collect(), // TODO(ed): This clone can probably be removed.
+            // TODO(ed): This clone can probably be removed.
+            Ok(statements) => statements
+                .into_iter()
+                .map(|(a, b)| (a.clone(), b))
+                .collect(),
             Err(statements) => {
                 statements.iter().for_each(|(statement, _)| {
                     error_no_panic!(self, statement.span, "Dependency cycle")

--- a/sylt-compiler/src/ty.rs
+++ b/sylt-compiler/src/ty.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use crate::typechecker::TyID;
+use sylt_common::TyID;
 
 #[derive(Debug, Clone)]
 pub enum Type {

--- a/sylt-compiler/src/ty.rs
+++ b/sylt-compiler/src/ty.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use crate::typechecker::TyID;
 
 #[derive(Debug, Clone)]
 pub enum Type {
@@ -14,11 +15,11 @@ pub enum Type {
     Float,
     Bool,
     Str,
-    Tuple(Vec<usize>),
-    List(usize),
-    Set(usize),
-    Dict(usize, usize),
-    Function(Vec<usize>, usize),
-    Blob(String, BTreeMap<String, usize>),
-    Enum(String, BTreeMap<String, usize>),
+    Tuple(Vec<TyID>),
+    List(TyID),
+    Set(TyID),
+    Dict(TyID, TyID),
+    Function(Vec<TyID>, TyID),
+    Blob(String, BTreeMap<String, TyID>),
+    Enum(String, BTreeMap<String, TyID>),
 }

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1208,11 +1208,8 @@ impl TypeChecker {
             ExpressionKind::Bool(_) => Ok(self.push_type(Type::Bool)),
             ExpressionKind::Nil => Ok(self.push_type(Type::Void)),
         }?;
-        let res_ty = self.find_type(res);
-        match res_ty {
-            // Type::Blob(_, _) => Ok(self.push_type(res_ty)),
-            _ => Ok(res),
-        }
+        expression.ty = Some(res);
+        Ok(res)
     }
 
     fn definition(&mut self, statement: &mut Statement, global: bool, ctx: TypeCtx) -> TypeResult<()> {

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1212,7 +1212,12 @@ impl TypeChecker {
         Ok(res)
     }
 
-    fn definition(&mut self, statement: &mut Statement, global: bool, ctx: TypeCtx) -> TypeResult<()> {
+    fn definition(
+        &mut self,
+        statement: &mut Statement,
+        global: bool,
+        ctx: TypeCtx,
+    ) -> TypeResult<()> {
         let span = statement.span;
         match &mut statement.kind {
             StatementKind::Definition { ident, kind, ty, value } => {

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use sylt_common::error::{Error, Helper, TypeError};
-use sylt_common::{FileOrLib, Type as RuntimeType};
+use sylt_common::{FileOrLib, TyID, Type as RuntimeType};
 use sylt_parser::statement::NameIdentifier;
 use sylt_parser::{
     expression::ComparisonKind, Assignable, AssignableKind, Expression, ExpressionKind, Identifier,
@@ -12,16 +12,6 @@ use crate::{ty::Type, NamespaceID};
 use std::collections::{BTreeMap, BTreeSet};
 
 type TypeResult<T> = Result<T, Vec<Error>>;
-
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Hash)]
-pub struct TyID(usize);
-
-impl std::fmt::Display for TyID {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let TyID(id) = self;
-        write!(f, "TyID({})", id)
-    }
-}
 
 trait Help {
     fn help(self, typechecker: &TypeChecker, span: Span, message: String) -> Self;

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::path::{Path, PathBuf};
 use sylt_common::error::Error;
-use sylt_common::{library_name, library_source, FileOrLib, Type as RuntimeType};
+use sylt_common::{library_name, library_source, FileOrLib, TyID, Type as RuntimeType};
 use sylt_tokenizer::{string_to_tokens, PlacedToken, Token};
 
 pub mod expression;
@@ -860,7 +860,7 @@ fn assignable_variant<'t>(ctx: Context<'t>, accessed: Assignable) -> ParseResult
 
     let (ctx, value) = match expression(ctx) {
         Ok(res) => res,
-        Err(_) => (ctx, Expression { span, kind: ExpressionKind::Nil }),
+        Err(_) => (ctx, Expression::new(span, ExpressionKind::Nil)),
     };
 
     use AssignableKind::Variant;

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -459,10 +459,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         [T::Ret, ..] => {
             let ctx = ctx.skip(1);
             let (ctx, value) = if matches!(ctx.token(), T::Newline) {
-                (
-                    ctx,
-                    Expression { span: ctx.span(), kind: ExpressionKind::Nil },
-                )
+                (ctx, Expression::new(ctx.span(), ExpressionKind::Nil))
             } else {
                 expression(ctx)?
             };
@@ -473,10 +470,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         [T::Loop, ..] => {
             let ctx = ctx.skip(1);
             let (ctx, condition) = if matches!(ctx.token(), T::Do) {
-                (
-                    ctx,
-                    Expression { span: ctx.span(), kind: ExpressionKind::Bool(true) },
-                )
+                (ctx, Expression::new(ctx.span(), ExpressionKind::Bool(true)))
             } else {
                 expression(ctx)?
             };


### PR DESCRIPTION
- Add newtypes for type ids in typechecker
- Loft TyID
- New expression constructor
- Mutable tree in the typechecker - this can be done cleaner
- Add types to the syntax tree
(Includes #630)

Does a lot of plumbing work (not all of it pretty) to be able to add types into the AST.