### PR TITLE
optimization a la edvard

### DIFF
--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -93,11 +93,9 @@ impl Compiler {
         let typechecker = typechecker::solve(&mut statements, &self.namespace_id_to_file)?;
 
         let ir = intermediate::compile(&typechecker, &statements);
-
         let usage_count = intermediate::count_usages(&ir);
-        dbg!(usage_count);
 
-        lua::generate(&ir, lua_file);
+        lua::generate(&ir, &usage_count, lua_file);
 
         Ok(())
     }

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -95,9 +95,6 @@ impl Compiler {
         let ir = intermediate::compile(&typechecker, &statements);
         let usage_count = intermediate::count_usages(&ir);
 
-        for i in ir.iter() {
-            eprintln!("> {:?}", i);
-        }
         lua::generate(&ir, &usage_count, lua_file);
 
         Ok(())

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -95,6 +95,9 @@ impl Compiler {
         let ir = intermediate::compile(&typechecker, &statements);
         let usage_count = intermediate::count_usages(&ir);
 
+        for i in ir.iter() {
+            eprintln!("> {:?}", i);
+        }
         lua::generate(&ir, &usage_count, lua_file);
 
         Ok(())

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -94,6 +94,9 @@ impl Compiler {
 
         let ir = intermediate::compile(&typechecker, &statements);
 
+        let usage_count = intermediate::count_usages(&ir);
+        dbg!(usage_count);
+
         lua::generate(&ir, lua_file);
 
         Ok(())

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -73,6 +73,7 @@ pub enum IR {
 
     Label(Label),
     Goto(Label),
+    Copy(Var, Var),
     Define(Var),
     Assign(Var, Var),
     Return(Var),
@@ -247,7 +248,7 @@ impl<'a> IRCodeGen<'a> {
             ExpressionKind::Get(ass) => {
                 let (code, source) = self.assignable(ass, ctx);
                 let dest = self.var();
-                ([code, vec![IR::Assign(dest, source)]].concat(), dest)
+                ([code, vec![IR::Copy(dest, source)]].concat(), dest)
             }
             ExpressionKind::Comparison(a, op, b) => {
                 let (aops, a) = self.expression(&a, ctx);
@@ -551,7 +552,6 @@ impl<'a> IRCodeGen<'a> {
                     pre_code,
                     code,
                     vec![
-                        IR::Define(res),
                         match kind {
                             ParserOp::Nop => IR::Assign(res, var),
                             ParserOp::Add => IR::Add(res, current, var),
@@ -819,6 +819,7 @@ pub(crate) fn count_usages(ops: &[IR]) -> HashMap<Var, usize> {
             | IR::Access(_, a, _)
             | IR::AssignAccess(_, _, a)
             | IR::Assign(_, a)
+            | IR::Copy(_, a)
             | IR::Return(a)
             | IR::If(a) => {
                 *table.entry(*a).or_insert(0) += 1;

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -14,7 +14,6 @@ impl Var {
     pub fn format(self) -> String {
         format!("V{}", self.0)
     }
-
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -557,15 +556,13 @@ impl<'a> IRCodeGen<'a> {
                 [
                     pre_code,
                     code,
-                    vec![
-                        match kind {
-                            ParserOp::Nop => IR::Assign(res, var),
-                            ParserOp::Add => IR::Add(res, current, var),
-                            ParserOp::Sub => IR::Sub(res, current, var),
-                            ParserOp::Mul => IR::Mul(res, current, var),
-                            ParserOp::Div => IR::Div(res, current, var),
-                        },
-                    ],
+                    vec![match kind {
+                        ParserOp::Nop => IR::Assign(res, var),
+                        ParserOp::Add => IR::Add(res, current, var),
+                        ParserOp::Sub => IR::Sub(res, current, var),
+                        ParserOp::Mul => IR::Mul(res, current, var),
+                        ParserOp::Div => IR::Div(res, current, var),
+                    }],
                     post_code,
                 ]
                 .concat()
@@ -804,8 +801,7 @@ pub(crate) fn count_usages(ops: &[IR]) -> HashMap<Var, usize> {
             | IR::HaltAndCatchFire(_) => {}
 
             // We cannot optimize things that are defined.
-            IR::Function(a, _)
-            | IR::Define(a) => {
+            IR::Function(a, _) | IR::Define(a) => {
                 *table.entry(*a).or_insert(0) += 2;
             }
 

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -793,8 +793,12 @@ pub(crate) fn count_usages(ops: &[IR]) -> HashMap<Var, usize> {
             | IR::Function(_, _)
             | IR::Label(_)
             | IR::Goto(_)
-            | IR::Define(_)
             | IR::HaltAndCatchFire(_) => {}
+
+            // We cannot optimize things that are defined.
+            IR::Define(a) => {
+                *table.entry(*a).or_insert(0) += 2;
+            }
 
             IR::Add(_, a, b)
             | IR::Sub(_, a, b)
@@ -808,6 +812,8 @@ pub(crate) fn count_usages(ops: &[IR]) -> HashMap<Var, usize> {
             | IR::LessEqual(_, a, b)
             | IR::Index(_, a, b)
             | IR::In(_, a, b)
+            | IR::Assign(a, b)
+            | IR::AssignAccess(a, _, b)
             | IR::AssignIndex(_, a, b) => {
                 *table.entry(*a).or_insert(0) += 1;
                 *table.entry(*b).or_insert(0) += 1;
@@ -817,8 +823,6 @@ pub(crate) fn count_usages(ops: &[IR]) -> HashMap<Var, usize> {
             | IR::Assert(a)
             | IR::Variant(_, _, a)
             | IR::Access(_, a, _)
-            | IR::AssignAccess(_, _, a)
-            | IR::Assign(_, a)
             | IR::Copy(_, a)
             | IR::Return(a)
             | IR::If(a) => {

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -782,6 +782,9 @@ pub(crate) fn compile(
     code
 }
 
+// TODO(ed): We could remove more dead-code if we built a dependency-graph
+// and removed all paths without side-effects, since they don't have
+// an observable effect.
 pub(crate) fn count_usages(ops: &[IR]) -> HashMap<Var, usize> {
     let mut table = HashMap::new();
     for op in ops {

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -10,11 +10,11 @@ use crate::{typechecker::TypeChecker, NamespaceID};
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct Var(pub usize);
 
-impl Display for Var {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Var(n) = self;
-        write!(f, "V{}", n)
+impl Var {
+    pub fn format(self) -> String {
+        format!("V{}", self.0)
     }
+
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -39,7 +39,6 @@ pub enum IR {
     Mul(Var, Var, Var),
     Div(Var, Var, Var),
     Neg(Var, Var),
-    Copy(Var, Var),
 
     Not(Var, Var),
 
@@ -248,7 +247,7 @@ impl<'a> IRCodeGen<'a> {
             ExpressionKind::Get(ass) => {
                 let (code, source) = self.assignable(ass, ctx);
                 let dest = self.var();
-                ([code, vec![IR::Copy(dest, source)]].concat(), dest)
+                ([code, vec![IR::Assign(dest, source)]].concat(), dest)
             }
             ExpressionKind::Comparison(a, op, b) => {
                 let (aops, a) = self.expression(&a, ctx);
@@ -814,7 +813,6 @@ pub(crate) fn count_usages(ops: &[IR]) -> HashMap<Var, usize> {
                 *table.entry(*b).or_insert(0) += 1;
             }
             IR::Neg(_, a)
-            | IR::Copy(_, a)
             | IR::Not(_, a)
             | IR::Assert(a)
             | IR::Variant(_, _, a)

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -1,5 +1,5 @@
 use crate::intermediate::{Var, IR};
-use std::io::Write;
+use std::{collections::HashMap, io::Write};
 
 macro_rules! write {
     ($out:expr, $msg:expr ) => {
@@ -11,296 +11,277 @@ macro_rules! write {
     };
 }
 
-pub fn bin_op(out: &mut dyn Write, t: &Var, a: &Var, b: &Var, op: &str) {
-    write!(out, "local ");
-    write!(out, "{}", t);
-    write!(out, " = ");
-    write!(out, "{}", a);
-    write!(out, " {} ", op);
-    write!(out, "{}", b);
+macro_rules! ii {
+    ( $self:expr, $var:expr, $fmt:literal, $a:expr ) => {
+        iis!($self, $var, $fmt, $self.expand($a))
+    };
+
+    ( $self:expr, $var:expr, $fmt:literal, $a:expr, $b:expr ) => {{
+        let a = $self.expand($a).to_string();
+        let b = $self.expand($b);
+        iis!($self, $var, $fmt, a, b)
+    }};
 }
 
-pub fn comma_sep(out: &mut dyn Write, vars: &[Var]) {
-    for (i, v) in vars.iter().enumerate() {
-        if i != 0 {
-            write!(out, ", ");
-        }
-        write!(out, "{}", v);
+macro_rules! iis {
+    ( $self:expr, $var:expr, $fmt:literal, $( $dep:expr ),* ) => {
+        Some(($var, format!($fmt, $( $dep ),*)))
+    };
+    ( $self:expr, $var:expr, $fmt:literal) => {
+        Some(($var, $fmt.into()))
+    };
+}
+
+struct Generator<'a, 'b> {
+    usage_count: &'a HashMap<Var, usize>,
+    out: &'b mut dyn Write,
+    lut: HashMap<Var, String>,
+}
+
+impl<'a, 'b> Generator<'a, 'b> {
+    pub fn new(usage_count: &'a HashMap<Var, usize>, out: &'b mut dyn Write) -> Self {
+        Self { usage_count, out, lut: HashMap::new() }
     }
-}
 
-pub fn generate(ir: &Vec<IR>, out: &mut dyn Write) {
-    write!(out, include_str!("preamble.lua"));
+    fn comma_sep(&mut self, vars: &[Var]) -> String {
+        vars.iter()
+            .map(|v| format!("{}", self.expand(v)))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 
-    let mut depth = 0;
-    for instruction in ir.iter() {
-        depth += match instruction {
-            IR::Else | IR::End => -1,
-            _ => 0,
-        };
-
-        for _ in 0..depth {
-            write!(out, "  ");
+    fn expand(&mut self, var: &Var) -> String {
+        match self.lut.get(var) {
+            Some(var) => var.into(),
+            None => var.to_string(),
         }
-        match instruction {
-            IR::Nil(t) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = __NIL");
-            }
-            IR::Int(t, i) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = {}", i);
-            }
-            IR::Bool(t, b) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = {}", b);
-            }
-            IR::Add(t, a, b) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__ADD(");
-                write!(out, "{}", a);
-                write!(out, ", ");
-                write!(out, "{}", b);
-                write!(out, ")");
-            }
-            IR::Sub(t, a, b) => bin_op(out, t, a, b, "-"),
-            IR::Mul(t, a, b) => bin_op(out, t, a, b, "*"),
-            IR::Div(t, a, b) => bin_op(out, t, a, b, "/"),
+    }
 
-            IR::Function(f, params) => {
-                write!(out, "local ");
-                write!(out, "function ");
-                write!(out, "{}", f);
-                write!(out, "(");
-                comma_sep(out, params);
-                write!(out, ")");
-                depth += 1;
-            }
-            IR::Neg(t, a) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "-");
-                write!(out, "{}", a);
-            }
-            IR::Copy(d, s) => {
-                write!(out, "local ");
-                write!(out, "{}", d);
-                write!(out, " = ");
-                write!(out, "{}", s);
-            }
-            IR::External(t, e) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, e);
-            }
-            IR::Call(t, f, args) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "{}", f);
-                write!(out, "(");
-                comma_sep(out, args);
-                write!(out, ")");
-            }
-            IR::Assert(v) => {
-                write!(out, "assert(");
-                write!(out, "{}", v);
-                write!(out, ", \":(\")");
-            }
-            IR::Str(t, s) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = \"{}\"", s);
-            }
-            IR::Float(t, f) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = {:?}", f);
-            }
-            IR::Equals(t, a, b) => bin_op(out, t, a, b, "=="),
-            IR::NotEquals(t, a, b) => bin_op(out, t, a, b, "~="),
-            IR::Greater(t, a, b) => bin_op(out, t, a, b, ">"),
-            IR::GreaterEqual(t, a, b) => bin_op(out, t, a, b, ">="),
-            IR::Less(t, a, b) => bin_op(out, t, a, b, "<"),
-            IR::LessEqual(t, a, b) => bin_op(out, t, a, b, "<="),
-            IR::In(t, a, b) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__CONTAINS(");
-                write!(out, "{}", a);
-                write!(out, ", ");
-                write!(out, "{}", b);
-                write!(out, ")");
-            }
+    fn define(&mut self, var: Var, value: String) {
+        self.lut.insert(var, value);
+    }
 
-            IR::Not(t, a) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "not ");
-                write!(out, "{}", a);
-            }
+    pub fn generate(&mut self, ir: &Vec<IR>) {
+        write!(self.out, include_str!("preamble.lua"));
 
-            IR::List(t, exprs) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__LIST{");
-                comma_sep(out, exprs);
-                write!(out, "}");
-            }
+        let mut depth = 0;
+        for instruction in ir.iter() {
+            depth += match instruction {
+                IR::Else | IR::End => -1,
+                _ => 0,
+            };
 
-            IR::Set(t, exprs) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__SET{");
-                write!(
-                    out,
-                    "{}",
+            for _ in 0..depth {
+                write!(self.out, "  ");
+            }
+            let expr = match instruction {
+                IR::Nil(t) => iis!(self, t, "__NIL"),
+                IR::Int(t, i) => iis!(self, t, "{}", i),
+                IR::Bool(t, b) => iis!(self, t, "{}", b),
+                IR::Add(t, a, b) => ii!(self, t, "__ADD({}, {})", a, b),
+                IR::Sub(t, a, b) => ii!(self, t, "({} - {})", a, b),
+                IR::Mul(t, a, b) => ii!(self, t, "({} * {})", a, b),
+                IR::Div(t, a, b) => ii!(self, t, "({} / {})", a, b),
+
+                IR::Neg(t, a) => ii!(self, t, "(-{})", a),
+
+                IR::Str(t, s) => iis!(self, t, "\"{}\"", s),
+                IR::Float(t, f) => iis!(self, t, "{:?}", f),
+
+                IR::Equals(t, a, b) => ii!(self, t, "({} == {})", a, b),
+                IR::LessEqual(t, a, b) => ii!(self, t, "({} <= {})", a, b),
+                IR::Less(t, a, b) => ii!(self, t, "({} < {})", a, b),
+                IR::GreaterEqual(t, a, b) => ii!(self, t, "({} >= {})", a, b),
+                IR::Greater(t, a, b) => ii!(self, t, "({} > {})", a, b),
+                IR::NotEquals(t, a, b) => ii!(self, t, "({} ~= {})", a, b),
+
+                IR::In(t, a, b) => ii!(self, t, "__CONTAINS({}, {})", a, b),
+
+                IR::Not(t, a) => ii!(self, t, "(not {})", a),
+
+                IR::List(t, exprs) => iis!(self, t, "__LIST{{ {} }}", self.comma_sep(exprs)),
+
+                IR::Set(t, exprs) => iis!(
+                    self,
+                    t,
+                    "__SET{{ {} }}",
                     exprs
                         .iter()
                         .map(|v| format!("[{}] = true", v))
                         .collect::<Vec<_>>()
                         .join(", ")
-                );
-                write!(out, "}");
-            }
+                ),
 
-            IR::Dict(t, exprs) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__DICT{");
-                write!(
-                    out,
-                    "{}",
+                IR::Dict(t, exprs) => iis!(
+                    self,
+                    t,
+                    "__DICT{{ {} }}",
                     exprs
                         .windows(2)
                         .step_by(2)
                         .map(|v| match v {
                             [k, v] => {
+                                let k = self.expand(k).to_string();
+                                let v = self.expand(v);
                                 format!("[{}] = {}", k, v)
                             }
                             _ => unreachable!(),
                         })
                         .collect::<Vec<_>>()
                         .join(", ")
-                );
-                write!(out, "}");
-            }
+                ),
 
-            IR::Blob(t, fields) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__BLOB{");
-                write!(
-                    out,
-                    "{}",
+                IR::Blob(t, fields) => iis!(
+                    self,
+                    t,
+                    "__BLOB{{ {} }}",
                     fields
                         .iter()
-                        .map(|(f, v)| format!("{} = {}", f, v))
+                        .map(|(f, v)| format!("{} = {}", f, self.expand(v)))
                         .collect::<Vec<_>>()
                         .join(", ")
-                );
-                write!(out, "}");
-            }
+                ),
 
-            IR::Tuple(t, exprs) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__TUPLE{");
-                comma_sep(out, exprs);
-                write!(out, "}");
-            }
+                IR::Tuple(t, exprs) => iis!(self, t, "__TUPLE{{ {} }}", self.comma_sep(exprs)),
 
-            IR::Define(t) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "nil");
+                IR::Assign(t, a) => {
+                    if self.usage_count.get(t).unwrap_or(&0) > &0 {
+                        let a = self.expand(a);
+                        write!(self.out, "local {} = {}", t, a);
+                    }
+                    None
+                }
+
+                IR::Variant(t, v, a) => {
+                    iis!(self, t, "__VARIANT{{ \"{}\", {} }}", v, self.expand(a))
+                }
+
+                IR::Index(t, a, i) => ii!(self, t, "__INDEX({}, {})", a, i),
+
+                IR::Function(f, params) => {
+                    write!(self.out, "local ");
+                    write!(self.out, "function ");
+                    write!(self.out, "{}", f);
+                    write!(self.out, "(");
+                    write!(
+                        self.out,
+                        "{}",
+                        params
+                            .iter()
+                            .map(|v| format!("{}", v))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                    write!(self.out, ")");
+                    None
+                }
+
+                IR::External(t, e) => {
+                    write!(self.out, "{}", t);
+                    write!(self.out, " = ");
+                    write!(self.out, e);
+                    None
+                }
+
+                IR::Call(t, f, args) => {
+                    write!(self.out, "local ");
+                    write!(self.out, "{}", t);
+                    write!(self.out, " = ");
+                    write!(self.out, "{}", f);
+                    let args = self.comma_sep(args).to_string();
+                    write!(self.out, "({})", args);
+                    None
+                }
+
+                IR::Assert(v) => {
+                    write!(self.out, "assert({}, \"Assert failed!\")", v);
+                    None
+                }
+
+                IR::Define(t) => {
+                    write!(self.out, "local ");
+                    write!(self.out, "{}", t);
+                    write!(self.out, " = ");
+                    write!(self.out, "nil");
+                    None
+                }
+
+                IR::If(a) => {
+                    write!(self.out, "if ");
+                    write!(self.out, "{}", a);
+                    write!(self.out, " then");
+                    depth += 1;
+                    None
+                }
+                IR::Else => {
+                    write!(self.out, "else");
+                    depth += 1;
+                    None
+                }
+                IR::End => {
+                    write!(self.out, "end");
+                    None
+                }
+                IR::Loop => {
+                    write!(self.out, "while true do");
+                    depth += 1;
+                    None
+                }
+                IR::Break => {
+                    write!(self.out, "break");
+                    None
+                }
+                IR::Return(t) => {
+                    write!(self.out, "return ");
+                    write!(self.out, "{}", t);
+                    None
+                }
+                IR::HaltAndCatchFire(msg) => {
+                    write!(self.out, "__CRASH(\"{}\")()", msg);
+                    None
+                }
+                IR::AssignIndex(t, i, a) => {
+                    if self.usage_count.get(t).unwrap_or(&0) > &0 {
+                        write!(self.out, "__ASSIGN_INDEX({}, {}, {})", t, i, a);
+                    }
+                    None
+                }
+                IR::Access(t, a, f) => iis!(self, t, "{}.{}", self.expand(a), f),
+                IR::AssignAccess(t, f, c) => {
+                    if self.usage_count.get(t).unwrap_or(&0) > &0 {
+                        let t = self.expand(t).to_string();
+                        write!(self.out, "{}.{}", t, f);
+                        write!(self.out, " = ");
+                        write!(self.out, "{}", c);
+                    }
+                    None
+                }
+                IR::Label(l) => {
+                    write!(self.out, "::{}::", l);
+                    None
+                }
+                IR::Goto(l) => {
+                    write!(self.out, "goto {}", l);
+                    None
+                }
+            };
+            match expr {
+                Some((var, value)) => {
+                    match self.usage_count.get(var).unwrap_or(&0) {
+                        0 => {},
+                        1 => self.define(*var, value),
+                        _ => {
+                            write!(self.out, "local {} = {}", var, value);
+                        }
+                    }
+                }
+                None => {}
             }
-            IR::Assign(t, a) => {
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "{}", a);
-            }
-            IR::If(a) => {
-                write!(out, "if ");
-                write!(out, "{}", a);
-                write!(out, " then");
-                depth += 1;
-            }
-            IR::Else => {
-                write!(out, "else");
-                depth += 1;
-            }
-            IR::End => {
-                write!(out, "end");
-            }
-            IR::Loop => {
-                write!(out, "while true do");
-                depth += 1;
-            }
-            IR::Break => {
-                write!(out, "break");
-            }
-            IR::Return(t) => {
-                write!(out, "return ");
-                write!(out, "{}", t);
-            }
-            IR::HaltAndCatchFire(msg) => {
-                write!(out, "__CRASH(\"{}\")()", msg);
-            }
-            IR::Variant(t, v, a) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__VARIANT{");
-                write!(out, "\"{}\", {}", v, a);
-                write!(out, "}");
-            }
-            IR::Index(t, a, i) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "__INDEX(");
-                write!(out, "{}, {}", a, i);
-                write!(out, ")");
-            }
-            IR::AssignIndex(t, i, a) => {
-                write!(out, "__ASSIGN_INDEX(");
-                write!(out, "{}, {}, {}", t, i, a);
-                write!(out, ")");
-            }
-            IR::Access(t, a, f) => {
-                write!(out, "local ");
-                write!(out, "{}", t);
-                write!(out, " = ");
-                write!(out, "{}.{}", a, f);
-            }
-            IR::AssignAccess(t, f, c) => {
-                write!(out, "{}.{}", t, f);
-                write!(out, " = ");
-                write!(out, "{}", c);
-            }
-            IR::Label(l) => {
-                write!(out, "::{}::", l);
-            }
-            IR::Goto(l) => {
-                write!(out, "goto {}", l);
-            }
+            write!(self.out, "\n");
         }
-        write!(out, "\n");
     }
+}
+
+pub fn generate(ir: &Vec<IR>, usage_count: &HashMap<Var, usize>, out: &mut dyn Write) {
+    Generator::new(usage_count, out).generate(ir);
 }

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1481,9 +1481,9 @@ impl TypeChecker {
                     Type::Unknown => Ok(()),
 
                     Type::Enum(enum_name, variants) => match (variants.get(var), maybe_v_b) {
-                        (Some(v_b), Some(v_a)) => self.unify(span, ctx, *v_a, *v_b).map(|_| ()),
-                        (None, Some(_)) => Ok(()),
-                        (_, None) => {
+                        (Some(_), None) => Ok(()),
+                        (Some(v_a), Some(v_b)) => self.unify(span, ctx, *v_a, *v_b).map(|_| ()),
+                        (None, _) => {
                             err_type_error!(
                                 self,
                                 span,

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -144,7 +144,7 @@ enum Constraint {
     IsContainedIn(TyID),
 
     Enum,
-    Variant(String, TyID),
+    Variant(String, Option<TyID>),
     TotalEnum(BTreeSet<String>),
 
     Variable,
@@ -567,10 +567,16 @@ impl TypeChecker {
                         };
                         self.add_constraint(
                             to_match,
-                            var.span,
-                            Constraint::Variant(branch.pattern.name.clone(), var.ty),
+                            span,
+                            Constraint::Variant(branch.pattern.name.clone(), Some(var.ty)),
                         );
                         self.stack.push(var);
+                    } else {
+                        self.add_constraint(
+                            to_match,
+                            span,
+                            Constraint::Variant(branch.pattern.name.clone(), None),
+                        );
                     }
                     self.check_constraints(span, ctx, to_match)?;
                     self.statement(&mut branch.body, ctx)?;
@@ -1471,12 +1477,13 @@ impl TypeChecker {
                     ),
                 },
 
-                Constraint::Variant(var, v_b) => match self.find_type(a) {
+                Constraint::Variant(var, maybe_v_b) => match self.find_type(a) {
                     Type::Unknown => Ok(()),
 
-                    Type::Enum(enum_name, vars) => match vars.get(var) {
-                        Some(v_a) => self.unify(span, ctx, *v_a, *v_b).map(|_| ()),
-                        None => {
+                    Type::Enum(enum_name, variants) => match (variants.get(var), maybe_v_b) {
+                        (Some(v_b), Some(v_a)) => self.unify(span, ctx, *v_a, *v_b).map(|_| ()),
+                        (None, Some(_)) => Ok(()),
+                        (_, None) => {
                             err_type_error!(
                                 self,
                                 span,

--- a/sylt/src/test.rs
+++ b/sylt/src/test.rs
@@ -220,6 +220,7 @@ fn program_tests() {
     .unwrap();
 
     for test in tests.iter() {
+        writeln!(std::io::stdout().lock(), " {}", test.path.to_str().unwrap()).unwrap();
         if !run_test(read_file, test) {
             failed.push(test);
             continue;

--- a/tests/bugs/unreachable_case_branch_603.sy
+++ b/tests/bugs/unreachable_case_branch_603.sy
@@ -1,0 +1,22 @@
+use std
+
+Enum :: enum
+    A,
+end
+
+f :: fn a do
+    case a do
+        A do
+
+        end
+        B do
+
+        end
+    end
+end
+
+start :: fn do
+    f' Enum.A
+end
+
+// error: Enum 'Enum' doesn't have variant 'A'

--- a/tests/bugs/unreachable_case_branch_603.sy
+++ b/tests/bugs/unreachable_case_branch_603.sy
@@ -19,4 +19,4 @@ start :: fn do
     f' Enum.A
 end
 
-// error: Enum 'Enum' doesn't have variant 'A'
+// error: Enum 'Enum' doesn't have variant 'B'

--- a/tests/hm_typing/faulty_enum_missing_variant.sy
+++ b/tests/hm_typing/faulty_enum_missing_variant.sy
@@ -13,4 +13,4 @@ start :: fn do
     end
 end
 
-// error: $MissingVariants
+// error: Enum 'A' doesn't have variant 'E'


### PR DESCRIPTION
We now use WAY less variables - the compilers time-complexity
hasn't changed but the memory usage has increased a lot for larger programs.

The steps are as follows:
 - Count the usages of each variable
 - Apply the following rule based on the count:
     - 0: remove
     - 1: inline (save the expression as a string and write it later)
     - 2+: use a variable
 - When writing code, we try to build the expressions as big as possible

There are some limitations with this.
We don't get optimal dead-code elimination, since a usage is a usage no matter
what. Consider this code:
```sylt
a :: 1
b :: a
c :: b
```
This we can only simplify to:
```sylt
a :: 1
b :: a

```
Since all other variables are used once in the original.
Though we could substitute it with:
```sylt



```
