### PR TITLE
case-expressions! (And some parser fixes)

### DIFF
--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -387,7 +387,11 @@ impl<'a> IRCodeGen<'a> {
                     .flatten()
                     .collect();
 
-                let fall_through_code = self.expression_block(out, fall_through.clone().unwrap_or_else(|| Vec::new()), ctx);
+                let fall_through_code = self.expression_block(
+                    out,
+                    fall_through.clone().unwrap_or_else(|| Vec::new()),
+                    ctx,
+                );
 
                 (
                     [

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -1,8 +1,9 @@
 use std::{collections::HashMap, fmt::Display};
 
 use sylt_parser::{
-    expression::ComparisonKind, Assignable, AssignableKind, CaseBranch, Expression, ExpressionKind,
-    Identifier, Op as ParserOp, Statement, StatementKind,
+    expression::{CaseBranch, ComparisonKind},
+    Assignable, AssignableKind, Expression, ExpressionKind, Identifier, Op as ParserOp, Statement,
+    StatementKind,
 };
 
 use crate::{typechecker::TypeChecker, NamespaceID};
@@ -347,6 +348,65 @@ impl<'a> IRCodeGen<'a> {
                 )
             }
 
+            ExpressionKind::Case { to_match, branches, fall_through } => {
+                let ss = self.variables.len();
+                let (cops, c) = self.expression(&to_match, ctx);
+                let tag = self.var();
+                let tag_index = self.var();
+                let value = self.var();
+                let value_index = self.var();
+
+                let out = self.var();
+
+                let branches_code = branches
+                    .iter()
+                    .map(|CaseBranch { pattern, variable, body }| {
+                        if let Some(var_name) = variable {
+                            self.variables.push(Variable {
+                                name: var_name.name.clone(),
+                                namespace: ctx.namespace,
+                                var: value,
+                            });
+                        }
+                        let body = self.expression_block(out, body.clone(), ctx);
+                        self.variables.truncate(ss);
+
+                        let exp_str = self.var();
+                        let cmp = self.var();
+                        [
+                            vec![
+                                IR::Str(exp_str, pattern.name.clone()),
+                                IR::Equals(cmp, exp_str, tag),
+                                IR::If(cmp),
+                            ],
+                            body,
+                            vec![IR::Else],
+                        ]
+                        .concat()
+                    })
+                    .flatten()
+                    .collect();
+
+                let fall_through_code = self.expression_block(out, fall_through.clone().unwrap_or_else(|| Vec::new()), ctx);
+
+                (
+                    [
+                        cops,
+                        vec![
+                            IR::Int(tag_index, 1),
+                            IR::Index(tag, c, tag_index),
+                            IR::Int(value_index, 2),
+                            IR::Index(value, c, value_index),
+                        ],
+                        branches_code,
+                        fall_through_code,
+                        (0..branches.len()).map(|_| IR::End).collect(),
+                    ]
+                    .concat(),
+                    out,
+                )
+            }
+
             ExpressionKind::Blob { fields, .. } => {
                 let ss = self.variables.len();
 
@@ -605,62 +665,6 @@ impl<'a> IRCodeGen<'a> {
                 stmt_code
             }
 
-            StatementKind::Case { to_match, branches, fall_through } => {
-                let ss = self.variables.len();
-                let (cops, c) = self.expression(&to_match, ctx);
-                let tag = self.var();
-                let tag_index = self.var();
-                let value = self.var();
-                let value_index = self.var();
-
-                let branches_code = branches
-                    .iter()
-                    .map(|CaseBranch { pattern, variable, body }| {
-                        if let Some(var_name) = variable {
-                            self.variables.push(Variable {
-                                name: var_name.name.clone(),
-                                namespace: ctx.namespace,
-                                var: value,
-                            });
-                        }
-                        let body = self.statement(body, ctx);
-                        self.variables.truncate(ss);
-
-                        let exp_str = self.var();
-                        let cmp = self.var();
-                        [
-                            vec![
-                                IR::Str(exp_str, pattern.name.clone()),
-                                IR::Equals(cmp, exp_str, tag),
-                                IR::If(cmp),
-                            ],
-                            body,
-                            vec![IR::Else],
-                        ]
-                        .concat()
-                    })
-                    .flatten()
-                    .collect();
-
-                let fall_through_code = fall_through
-                    .as_ref()
-                    .map(|stmt| self.statement(stmt, ctx))
-                    .unwrap_or_else(Vec::new);
-
-                [
-                    cops,
-                    vec![
-                        IR::Int(tag_index, 1),
-                        IR::Index(tag, c, tag_index),
-                        IR::Int(value_index, 2),
-                        IR::Index(value, c, value_index),
-                    ],
-                    branches_code,
-                    fall_through_code,
-                    (0..branches.len()).map(|_| IR::End).collect(),
-                ]
-                .concat()
-            }
             StatementKind::Loop { condition, body } => {
                 let (cops, c) = self.expression(&condition, ctx);
                 let l = self.label();

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -580,9 +580,7 @@ impl TypeChecker {
                 self.unify_option(span, ctx, expression_ret, target_ret)
             }
 
-            StatementKind::Definition { .. } => {
-                self.definition(statement, false, ctx)
-            }
+            StatementKind::Definition { .. } => self.definition(statement, false, ctx),
 
             StatementKind::Loop { condition, body } => {
                 let (ret, condition) = self.expression(condition, ctx)?;
@@ -1071,7 +1069,8 @@ impl TypeChecker {
                     // - for example - this makes it more permissive than if you place it after the
                     // `self.expression_block`.
                     self.check_constraints(span, ctx, to_match)?;
-                    let (branch_ret, branch) = self.expression_block(span, &mut branch.body, ctx)?;
+                    let (branch_ret, branch) =
+                        self.expression_block(span, &mut branch.body, ctx)?;
                     value = self.unify_option(span, ctx, value, branch)?;
                     ret = self.unify_option(span, ctx, ret, branch_ret)?;
                     self.stack.truncate(ss);

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1068,10 +1068,13 @@ impl TypeChecker {
                         span,
                         Constraint::Variant(name.clone(), constraint),
                     );
+                    // NOTE(ed): This unifies the variable with the enum, so it injects a function
+                    // - for example - this makes it more permissive than if you place it after the
+                    // `self.expression_block`.
+                    self.check_constraints(span, ctx, to_match)?;
                     let (branch_ret, branch) = self.expression_block(span, &mut branch.body, ctx)?;
                     value = self.unify_option(span, ctx, value, branch)?;
                     ret = self.unify_option(span, ctx, ret, branch_ret)?;
-                    self.check_constraints(span, ctx, to_match)?;
                     self.stack.truncate(ss);
                     branch_names.insert(name.clone());
                 }

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -10,7 +10,7 @@ use sylt_tokenizer::{string_to_tokens, PlacedToken, Token};
 pub mod expression;
 pub mod statement;
 pub use self::expression::{Expression, ExpressionKind};
-pub use self::statement::{CaseBranch, Statement, StatementKind};
+pub use self::statement::{Statement, StatementKind};
 
 pub use sylt_tokenizer::Span;
 
@@ -1297,26 +1297,6 @@ impl PrettyPrint for Statement {
                 write!(f, "<Ass> {:?}\n", kind)?;
                 target.pretty_print(f, indent + 1)?;
                 value.pretty_print(f, indent + 1)?;
-                return Ok(());
-            }
-            SK::Case { to_match, branches, fall_through } => {
-                write!(f, "<Case>\n")?;
-                to_match.pretty_print(f, indent + 1)?;
-                for CaseBranch { pattern, variable, body } in branches.iter() {
-                    write_indent(f, indent + 1)?;
-                    write!(
-                        f,
-                        "{} {:?}\n",
-                        pattern.name,
-                        variable.as_ref().map(|x| &x.name)
-                    )?;
-                    body.pretty_print(f, indent + 2)?;
-                }
-                write_indent(f, indent + 1)?;
-                if let Some(fall_through) = fall_through {
-                    write!(f, "else")?;
-                    fall_through.pretty_print(f, indent + 2)?;
-                }
                 return Ok(());
             }
             SK::Loop { condition, body } => {

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -23,13 +23,6 @@ impl NameIdentifier {
 
 type Alias = Identifier;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct CaseBranch {
-    pub pattern: Identifier,
-    pub variable: Option<Identifier>,
-    pub body: Statement,
-}
-
 /// The different kinds of [Statement]s.
 ///
 /// There are both shorter statements like `a = b + 1` as well as longer
@@ -111,15 +104,6 @@ pub enum StatementKind {
         ident: Identifier,
         kind: VarKind,
         ty: Type,
-    },
-
-    /// A super branchy branch.
-    ///
-    /// `case <expression> do (<pattern> [<variable] <statement>)* [else <statement>] end`.
-    Case {
-        to_match: Expression,
-        branches: Vec<CaseBranch>,
-        fall_through: Option<Box<Statement>>,
     },
 
     /// Do something as long as something else evaluates to true.
@@ -440,74 +424,6 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
             };
             let (ctx, body) = statement(ctx)?;
             (ctx.prev(), Loop { condition, body: Box::new(body) })
-        }
-
-        // `case <expression> do (<branch>)* [else <statement> end] end`
-        [T::Case, ..] => {
-            let (ctx, skip_newlines) = ctx.push_skip_newlines(true);
-            let (ctx, to_match) = expression(ctx.skip(1))?;
-            let mut ctx = expect!(ctx, T::Do);
-
-            let mut branches = Vec::new();
-            loop {
-                match ctx.token() {
-                    T::EOF | T::Else | T::End => {
-                        break;
-                    }
-
-                    T::Newline => {
-                        ctx = ctx.skip(1);
-                    }
-
-                    T::Identifier(pattern) if is_capitalized(pattern) => {
-                        let pattern = Identifier::new(ctx.span(), pattern.clone());
-                        ctx = ctx.skip(1);
-                        let (ctx_, variable) = match ctx.token() {
-                            T::Identifier(capture) if !is_capitalized(capture) => (
-                                ctx.skip(1),
-                                Some(Identifier::new(ctx.span(), capture.clone())),
-                            ),
-                            T::Identifier(_) => {
-                                raise_syntax_error!(
-                                    ctx,
-                                    "Variables have to start with a lowercase letter"
-                                );
-                            }
-                            _ => (ctx, None),
-                        };
-                        let (ctx_, body) = statement_or_block(ctx_)?;
-                        ctx = ctx_;
-
-                        branches.push(CaseBranch { pattern, variable, body });
-                    }
-
-                    T::Identifier(_) => {
-                        raise_syntax_error!(
-                            ctx,
-                            "Enum variants have to start with a captial letter"
-                        );
-                    }
-
-                    _ => {
-                        raise_syntax_error!(
-                            ctx,
-                            "Expected a branch - but a branch cannot start with {:?}",
-                            ctx.token()
-                        );
-                    }
-                }
-            }
-            let (ctx, fall_through) = if matches!(ctx.token(), T::Else) {
-                let (ctx, fall_through) = statement_or_block(ctx.skip(1))?;
-                (ctx, Some(Box::new(fall_through)))
-            } else {
-                (ctx, None)
-            };
-
-            let ctx = ctx.pop_skip_newlines(skip_newlines);
-            let ctx = expect!(ctx, T::End, "Expected 'end' to finish of case-statement");
-
-            (ctx, Case { to_match, branches, fall_through })
         }
 
         // Enum declaration: `Abc :: enum A, B, C end`

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -326,6 +326,9 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
             write_indents(dest, indent)?;
             write!(dest, "end")?;
         }
+        ExpressionKind::Case { .. } => {
+            unreachable!()
+        }
         ExpressionKind::Function { name: _, params, ret, body } => {
             write!(dest, "fn")?;
             if !params.is_empty() {
@@ -499,29 +502,6 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             write_expression(dest, indent, value)?;
         }
         StatementKind::EmptyStatement => (),
-        StatementKind::Case { to_match, branches, fall_through } => {
-            write_indents(dest, indent)?;
-            write!(dest, "case ")?;
-            write_expression(dest, indent, to_match)?;
-            write!(dest, " do\n")?;
-            for branch in branches {
-                write_indents(dest, indent + 1)?;
-                write_identifier(dest, branch.pattern)?;
-                if let Some(var) = branch.variable {
-                    write!(dest, " ")?;
-                    write_identifier(dest, var)?;
-                }
-                write!(dest, "\n")?;
-                write_statement(dest, indent + 1, branch.body)?;
-            }
-            if let Some(fall_through) = fall_through {
-                write_indents(dest, indent + 1)?;
-                write!(dest, "else\n")?;
-                write_statement(dest, indent + 1, *fall_through)?;
-            }
-            write_indents(dest, indent)?;
-            write!(dest, "end\n")?;
-        }
         StatementKind::Loop { condition, body } => {
             write_indents(dest, indent)?;
             write!(dest, "loop ")?;

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -327,7 +327,6 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
             write!(dest, "end")?;
         }
         ExpressionKind::Case { to_match, branches, fall_through } => {
-            write_indents(dest, indent)?;
             write!(dest, "case ")?;
             write_expression(dest, indent, *to_match)?;
             write!(dest, " do\n")?;
@@ -351,6 +350,8 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
                 for stmt in fall_through.into_iter() {
                     write_statement(dest, indent + 1, stmt)?;
                 }
+                write_indents(dest, indent + 1)?;
+                write!(dest, "end\n")?;
             }
             write_indents(dest, indent)?;
             write!(dest, "end\n")?;

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -342,6 +342,8 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
                 for stmt in branch.body.into_iter() {
                     write_statement(dest, indent + 1, stmt)?;
                 }
+                write_indents(dest, indent + 1)?;
+                write!(dest, "end\n")?;
             }
             if let Some(fall_through) = fall_through {
                 write_indents(dest, indent + 1)?;

--- a/tests/bugs/unreachable_case_branch_603.sy
+++ b/tests/bugs/unreachable_case_branch_603.sy
@@ -6,12 +6,8 @@ end
 
 f :: fn a do
     case a do
-        A do
-
-        end
-        B do
-
-        end
+        A -> end
+        B -> end
     end
 end
 

--- a/tests/enums/case_only_else.sy
+++ b/tests/enums/case_only_else.sy
@@ -4,7 +4,7 @@ end
 
 start :: fn do
     case A.X do
-        else do end
+        else end
     end
 end
 

--- a/tests/enums/faulty_deduce_through_case.sy
+++ b/tests/enums/faulty_deduce_through_case.sy
@@ -5,13 +5,13 @@ end
 
 f :: fn a do
     case a do
-        X x do
+        X x ->
             x + 1
         end
-        Y x do
+        Y x ->
             x + "a"
         end
-        else do <!> end
+        else <!> end
     end
 end
 

--- a/tests/enums/simple_case.sy
+++ b/tests/enums/simple_case.sy
@@ -8,16 +8,12 @@ out := ""
 
 f :: fn a do
     case a do
-        X do
-            out = out + "X"
-        end
-        Y x do
+        X -> out = out + "X" end
+        Y x ->
             out = out + "Y"
             x <=> 2
         end
-        else do
-            out = out + "?"
-        end
+        else out = out + "?" end
     end
 end
 

--- a/tests/enums/sneaky_function.sy
+++ b/tests/enums/sneaky_function.sy
@@ -4,10 +4,8 @@ end
 
 f :: fn a: M do
     case a do
-        J x do
-            x()
-        end
-        else do end
+        J x -> x() end
+        else end
     end
 end
 

--- a/tests/expression/case_expression_simple.sy
+++ b/tests/expression/case_expression_simple.sy
@@ -1,0 +1,25 @@
+A :: enum
+    B int
+    C int
+    D
+end
+
+start :: fn do
+    12 <=> 1 + case A.B 1 do
+        B a -> a + 10 end
+        C a -> a end
+        D -> 0 end
+    end
+
+    2 <=> 1 + case A.C 1 do
+        B a -> a + 10 end
+        C a -> a end
+        D -> 0 end
+    end
+
+    -99 <=> 1 + case A.D do
+        B a -> a + 10 end
+        C a -> a end
+        else -100 end
+    end
+end

--- a/tests/expression/faulty_case_body.sy
+++ b/tests/expression/faulty_case_body.sy
@@ -1,0 +1,16 @@
+A :: enum
+    A
+end
+
+f :: fn -> int
+    case A.A do
+        A ->
+            ret "abc"
+        end
+    end
+    1
+end
+
+start :: fn do end
+
+// error: A 'str' cannot be a 'int'

--- a/tests/hm_typing/faulty_enum_extra_variant.sy
+++ b/tests/hm_typing/faulty_enum_extra_variant.sy
@@ -8,9 +8,9 @@ end
 
 start :: fn do
     case A.Q do
-        Q do end
-        W do end
-        E do end
+        Q -> end
+        W -> end
+        E -> end
     end
 end
 

--- a/tests/hm_typing/faulty_enum_missing_variant.sy
+++ b/tests/hm_typing/faulty_enum_missing_variant.sy
@@ -7,9 +7,9 @@ end
 
 start :: fn do
     case A.Q do
-        Q do end
-        W do end
-        E do end
+        Q -> end
+        W -> end
+        E -> end
     end
 end
 

--- a/tests/hm_typing/total_enum.sy
+++ b/tests/hm_typing/total_enum.sy
@@ -7,8 +7,8 @@ end
 
 start :: fn do
     case A.Q do
-        Q do end
-        W do end
-        E do end
+        Q -> end
+        W -> end
+        E -> end
     end
 end


### PR DESCRIPTION
Now case-expressions are a thing. The syntax is slightly changed to have `->` in them instead of `do`. I also found a funky parser-bug and with that accidentally imporved the error messages. :shrug: 

There was also a bug with us not type-checking return-statements in case-statements, we do that now aswell. ;)