### PR TITLE
Pure std

### DIFF
--- a/std/common.sy
+++ b/std/common.sy
@@ -1,11 +1,8 @@
-dbg :: pu x ->
-    print(x)
-    x
-end
+dbg : pu *X -> *X : external
 
-args: pu -> {str:str} : external
+args: fn -> {str:str} : external
 thread_sleep: fn float -> void : external
-print: pu *X -> void : external
+print: fn *X -> void : external
 
 spy :: pu tag: str, x ->
     dbg(tag + " " + as_str(x))
@@ -17,6 +14,6 @@ split: pu str -> [str] : external
 
 as_float: pu int -> float : external
 as_int: pu float -> int : external
-as_char: pu str -> int : external
+as_char: fn str -> int : external
 as_chars: pu str -> [int] : external
 as_str: pu *X -> str : external

--- a/std/common.sy
+++ b/std/common.sy
@@ -14,6 +14,6 @@ split: pu str -> [str] : external
 
 as_float: pu int -> float : external
 as_int: pu float -> int : external
-as_char: fn str -> int : external
+as_char: pu str -> int : external
 as_chars: pu str -> [int] : external
 as_str: pu *X -> str : external

--- a/std/common.sy
+++ b/std/common.sy
@@ -1,22 +1,22 @@
-dbg :: fn x ->
+dbg :: pu x ->
     print(x)
     x
 end
 
-args: fn -> {str:str} : external
+args: pu -> {str:str} : external
 thread_sleep: fn float -> void : external
-print: fn *X -> void : external
+print: pu *X -> void : external
 
-spy :: fn tag: str, x ->
+spy :: pu tag: str, x ->
     dbg(tag + " " + as_str(x))
     x
 end
 
-unsafe_force: fn *X -> *Y : external
-split: fn str -> [str] : external
+unsafe_force: pu *X -> *Y : external
+split: pu str -> [str] : external
 
-as_float: fn int -> float : external
-as_int: fn float -> int : external
-as_char: fn str -> int : external
-as_chars: fn str -> [int] : external
-as_str: fn *X -> str : external
+as_float: pu int -> float : external
+as_int: pu float -> int : external
+as_char: pu str -> int : external
+as_chars: pu str -> [int] : external
+as_str: pu *X -> str : external

--- a/std/common.sy
+++ b/std/common.sy
@@ -1,3 +1,5 @@
+from maybe use (Maybe)
+
 dbg : pu *X -> *X : external
 
 args: fn -> {str:str} : external
@@ -14,6 +16,6 @@ split: pu str -> [str] : external
 
 as_float: pu int -> float : external
 as_int: pu float -> int : external
-as_char: pu str -> int : external
+as_char: pu str -> Maybe : external
 as_chars: pu str -> [int] : external
 as_str: pu *X -> str : external

--- a/std/container.sy
+++ b/std/container.sy
@@ -1,4 +1,4 @@
 add: fn {*ITEM}, *ITEM -> void : external
 remove: fn {*ITEM}, *ITEM -> void : external
-len: fn<C: Container> *C -> int : external
+len: pu<C: Container> *C -> int : external
 clear: fn<C: Container> *C -> void : external

--- a/std/list.sy
+++ b/std/list.sy
@@ -2,10 +2,10 @@ from container use len
 
 random_choice: fn [*ITEM] -> *ITEM : external
 for_each: fn [*ITEM], fn *ITEM -> void -> void : external
-map: fn [*ITEM], fn *ITEM -> *OUT -> [*OUT] : external
-reduce: fn [*ITEM], (fn *ITEM, *ITEM -> *OUT) -> *OUT : external
-fold: fn [*ITEM], *OUT, (fn *ITEM, *OUT -> *OUT) -> *OUT : external
-filter: fn [*ITEM], fn *ITEM -> bool -> [*ITEM] : external
+map: pu [*ITEM], pu *ITEM -> *OUT -> [*OUT] : external
+reduce: pu [*ITEM], (pu *ITEM, *ITEM -> *OUT) -> *OUT : external
+fold: pu [*ITEM], *OUT, (pu *ITEM, *OUT -> *OUT) -> *OUT : external
+filter: pu [*ITEM], pu *ITEM -> bool -> [*ITEM] : external
 push: fn [*ITEM], *ITEM -> void : external
 prepend: fn [*ITEM], *ITEM -> void : external
 pop: fn [*ITEM] -> *ITEM : external

--- a/std/math.sy
+++ b/std/math.sy
@@ -59,3 +59,7 @@ dot :: pu v1: (float, float), v2: (float, float) -> float
 end
 
 random : fn -> float : external
+
+/// args: min, max
+/// error if max < min
+randint : fn int, int -> int : external

--- a/std/math.sy
+++ b/std/math.sy
@@ -1,4 +1,4 @@
-abs : fn<N: Num> *N -> *N: fn n ->
+abs : pu<N: Num> *N -> *N: pu n ->
     if n < 0 do
         -n
     else do
@@ -6,18 +6,18 @@ abs : fn<N: Num> *N -> *N: fn n ->
     end
 end
 
-atan2: fn float, float -> float : external
-sin: fn float -> float : external
-cos: fn float -> float : external
-floor: fn<N: Num> *N -> int : external
-sqrt: fn float -> float : external
-sign: fn<N: Num> *N -> *N : external
+atan2: pu float, float -> float : external
+sin: pu float -> float : external
+cos: pu float -> float : external
+floor: pu<N: Num> *N -> int : external
+sqrt: pu float -> float : external
+sign: pu<N: Num> *N -> *N : external
 
-clamp :: fn x, lo, hi ->
+clamp :: pu x, lo, hi ->
     min(hi, max(x, lo))
 end
 
-min : fn<N: Num> *N, *N -> *N : fn a, b ->
+min : pu<N: Num> *N, *N -> *N : pu a, b ->
     if a < b do
         a
     else do
@@ -25,35 +25,35 @@ min : fn<N: Num> *N, *N -> *N : fn a, b ->
     end
 end
 
-max : fn<N: Num> *N, *N -> *N : fn a, b ->
+max : pu<N: Num> *N, *N -> *N : pu a, b ->
     if a > b do a
     else do b
     end
 end
 
-rem: fn<N: Num> *N, *N -> *N : external
-pow: fn float, float -> float : external
-div: fn int, int -> int : external
+rem: pu<N: Num> *N, *N -> *N : external
+pow: pu float, float -> float : external
+div: pu int, int -> int : external
 
-angle :: fn v: (float, float) -> float
+angle :: pu v: (float, float) -> float
     atan2(v[0], v[1])
 end
 
-magnitude_squared :: fn v: (float, float) -> float
+magnitude_squared :: pu v: (float, float) -> float
     dot(v, v)
 end
 
-magnitude :: fn v: (float, float) -> float
+magnitude :: pu v: (float, float) -> float
     sqrt(magnitude_squared(v))
 end
 
-normalize :: fn v: (float, float) -> (float, float)
+normalize :: pu v: (float, float) -> (float, float)
     mag :: magnitude(v)
     (v[0] / mag, v[1] / mag)
 end
 
-reflect: fn (float, float), (float, float) -> (float, float) : external
+reflect: pu (float, float), (float, float) -> (float, float) : external
 
-dot :: fn v1: (float, float), v2: (float, float) -> float
+dot :: pu v1: (float, float), v2: (float, float) -> float
     v1[0] * v2[0] + v1[1] * v2[1]
 end

--- a/std/math.sy
+++ b/std/math.sy
@@ -57,3 +57,5 @@ reflect: pu (float, float), (float, float) -> (float, float) : external
 dot :: pu v1: (float, float), v2: (float, float) -> float
     v1[0] * v2[0] + v1[1] * v2[1]
 end
+
+random : fn -> float : external

--- a/std/maybe.sy
+++ b/std/maybe.sy
@@ -4,27 +4,27 @@ Maybe :: enum
     None
 end
 
-orDefault :: fn maybe, a ->
+orDefault :: pu maybe, a ->
     case maybe do
         Just x -> x end
         None -> a end
     end
 end
 
-flatten :: fn maybe ->
+flatten :: pu maybe ->
     case maybe do
         Just x -> x end
         None -> Maybe.None end
     end
 end
 
-isJust :: fn maybe -> bool
+isJust :: pu maybe -> bool
     case maybe do
         Just _ -> true end
         None -> false end
     end
 end
 
-isNone :: fn maybe -> bool
+isNone :: pu maybe -> bool
     not isJust' maybe
 end

--- a/std/preamble.sy
+++ b/std/preamble.sy
@@ -26,6 +26,7 @@ from math use (
     div,
     pow,
     random,
+    randint,
 )
 
 from container use len

--- a/std/preamble.sy
+++ b/std/preamble.sy
@@ -25,6 +25,7 @@ from math use (
     rem,
     div,
     pow,
+    random,
 )
 
 from container use len

--- a/sylt-compiler/src/preamble.lua
+++ b/sylt-compiler/src/preamble.lua
@@ -484,5 +484,6 @@ function __CONTAINS(a, b)
 end
 
 random = math.random
+randint = math.random
 
 -- End Sylt preamble

--- a/sylt-compiler/src/preamble.lua
+++ b/sylt-compiler/src/preamble.lua
@@ -483,4 +483,6 @@ function __CONTAINS(a, b)
     assert(false, "Invalid contains!")
 end
 
+random = math.random
+
 -- End Sylt preamble

--- a/sylt-compiler/src/preamble.lua
+++ b/sylt-compiler/src/preamble.lua
@@ -461,6 +461,7 @@ end
 
 as_str = tostring
 print = print
+function dbg(x) print(x); return x end
 
 unsafe_force = __IDENTITY
 

--- a/sylt-compiler/src/preamble.lua
+++ b/sylt-compiler/src/preamble.lua
@@ -408,7 +408,14 @@ function as_int(x)
     return f
 end
 floor = math.floor
-as_char = string.byte
+function as_char(s)
+   char = string.byte(s)
+   if char ~= nil then
+      return __VARIANT({"Just", char})
+   else
+      return __VARIANT({"None"})
+   end
+end
 function as_chars(s)
     local chars = {}
     local len = string.len(s)

--- a/sylt-compiler/src/ty.rs
+++ b/sylt-compiler/src/ty.rs
@@ -2,6 +2,13 @@ use std::collections::BTreeMap;
 use sylt_common::TyID;
 
 #[derive(Debug, Clone)]
+pub enum Purity {
+    Pure,
+    Impure,
+    Undefined,
+}
+
+#[derive(Debug, Clone)]
 pub enum Type {
     Unknown,
 
@@ -20,7 +27,7 @@ pub enum Type {
     List(TyID),
     Set(TyID),
     Dict(TyID, TyID),
-    Function(Vec<TyID>, TyID),
+    Function(Vec<TyID>, TyID, Purity),
     Blob(String, BTreeMap<String, TyID>),
     Enum(String, BTreeMap<String, TyID>),
 }

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1467,7 +1467,7 @@ impl TypeChecker {
                 Box::new(self.inner_bake_type(ty_k, seen)),
                 Box::new(self.inner_bake_type(ty_v, seen)),
             ),
-            Type::Function(args, ret, purity) => RuntimeType::Function(
+            Type::Function(args, ret, _) => RuntimeType::Function(
                 args.iter()
                     .map(|ty| self.inner_bake_type(*ty, seen))
                     .collect(),
@@ -1801,6 +1801,18 @@ impl TypeChecker {
                     Type::Function(b_args, b_ret, b_purity),
                 ) => {
                     // TODO: Make sure there is one place this is checked.
+                    match (a_purity, b_purity) {
+                            (Purity::Undefined, _) |
+                            (_, Purity::Undefined) |
+                            (Purity::Pure, Purity::Pure) |
+                            (Purity::Impure, Purity::Impure) => (),
+                            (_, _) => return err_type_error!(
+                                self,
+                                span,
+                                TypeError::Impurity,
+                                "Cannot use impure function implementations for pure function declarations"
+                            ),
+                        }
                     if a_args.len() != b_args.len() {
                         return err_type_error!(
                             self,

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -158,8 +158,6 @@ enum Constraint {
     TotalEnum(BTreeSet<String>),
 
     Variable,
-
-    Pure,
 }
 
 pub struct TypeChecker {
@@ -448,10 +446,6 @@ impl TypeChecker {
                 let a = parse_constraint_arg(self, span, &constraint.args[0].name, seen)?;
                 self.add_constraint(var, span, Constraint::Contains(a));
                 self.add_constraint(a, span, Constraint::IsContainedIn(var));
-            }
-            "Pure" => {
-                check_constraint_arity(self, span, "Pure", num_args, 0)?;
-                self.add_constraint(var, span, Constraint::Pure);
             }
             x => return err_type_error!(self, span, TypeError::UnknownConstraint(x.into())),
         }
@@ -1690,17 +1684,6 @@ impl TypeChecker {
 
                     _ => Ok(()),
                 },
-
-                Constraint::Pure => match self.find_type(a) {
-                    Type::Function(_, _, _) => Ok(()),
-                    Type::Unknown => Ok(()),
-                    _ => err_type_error!(
-                        self,
-                        span,
-                        TypeError::Impurity,
-                        "Only functions can be pure, but this is not a function"
-                    ),
-                },
             }
             .help(self, *original_span, "Requirement came from".to_string())?
         }
@@ -1974,7 +1957,6 @@ impl TypeChecker {
                         }
                         C::TotalEnum(x) => C::TotalEnum(x.clone()),
                         C::Variable => C::Variable,
-                        C::Pure => C::Pure,
                     },
                     *span,
                 )

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -503,11 +503,7 @@ impl TypeChecker {
                         }
                     }
                 }
-                let purity = if *is_pure {
-                    Purity::Pure
-                } else {
-                    Purity::Undefined
-                };
+                let purity = is_pure.then(|| Purity::Pure).unwrap_or(Purity::Undefined);
                 Type::Function(params, ret, purity)
             }
 
@@ -1367,11 +1363,7 @@ impl TypeChecker {
                     .map(|_| self.push_type(Type::Unknown))
                     .collect();
                 let ret = self.push_type(Type::Unknown);
-                let purity = if *pure {
-                    Purity::Pure
-                } else {
-                    Purity::Undefined
-                };
+                let purity = pure.then(|| Purity::Pure).unwrap_or(Purity::Impure);
                 let fn_ty = self.push_type(Type::Function(args, ret, purity));
                 self.unify(span, ctx, defined_ty, fn_ty)?;
                 let var = Variable { ident, ty: fn_ty, kind, span };

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -478,7 +478,7 @@ impl TypeChecker {
                 return self.type_assignable(ctx, assignable);
             }
 
-            Fn { constraints, params, ret, pure } => {
+            Fn { constraints, params, ret, is_pure } => {
                 let params = params
                     .iter()
                     .map(|t| self.inner_resolve_type(span, ctx, t, seen))
@@ -503,7 +503,7 @@ impl TypeChecker {
                         }
                     }
                 }
-                let purity = if *pure {
+                let purity = if *is_pure {
                     Purity::Pure
                 } else {
                     Purity::Undefined

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -188,7 +188,7 @@ pub enum TypeKind {
         constraints: BTreeMap<String, Vec<TypeConstraint>>,
         params: Vec<Type>,
         ret: Box<Type>,
-        pure: bool,
+        is_pure: bool,
     },
     /// Tuples can mix types since the length is constant.
     Tuple(Vec<Type>),
@@ -683,7 +683,7 @@ pub fn parse_type<'t>(ctx: Context<'t>) -> ParseResult<'t, Type> {
                     constraints,
                     params,
                     ret: Box::new(ret),
-                    pure: matches!(ty, T::Pu),
+                    is_pure: matches!(ty, T::Pu),
                 },
             )
         }
@@ -1394,7 +1394,7 @@ impl Display for Type {
                 name.pretty_print(f, 0)?;
                 write!(f, ")")?;
             }
-            TypeKind::Fn { constraints, params, ret, pure } => {
+            TypeKind::Fn { constraints, params, ret, is_pure: pure } => {
                 if *pure {
                     write!(f, "Pu ")?;
                 } else {

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -188,6 +188,7 @@ pub enum TypeKind {
         constraints: BTreeMap<String, Vec<TypeConstraint>>,
         params: Vec<Type>,
         ret: Box<Type>,
+        pure: bool,
     },
     /// Tuples can mix types since the length is constant.
     Tuple(Vec<Type>),
@@ -604,10 +605,6 @@ pub fn parse_type<'t>(ctx: Context<'t>) -> ParseResult<'t, Type> {
 
             let mut constraints = BTreeMap::new();
 
-            if let T::Pu = ty {
-                constraints.insert("Pure".to_string(), Vec::new());
-            }
-
             let ctx = if matches!(ctx.token(), T::Less) {
                 let mut ctx = ctx.skip(1);
                 'outer: loop {
@@ -680,7 +677,15 @@ pub fn parse_type<'t>(ctx: Context<'t>) -> ParseResult<'t, Type> {
                     }
                 }
             };
-            (ctx, Fn { constraints, params, ret: Box::new(ret) })
+            (
+                ctx,
+                Fn {
+                    constraints,
+                    params,
+                    ret: Box::new(ret),
+                    pure: matches!(ty, T::Pu),
+                },
+            )
         }
 
         // Tuple
@@ -1389,8 +1394,12 @@ impl Display for Type {
                 name.pretty_print(f, 0)?;
                 write!(f, ")")?;
             }
-            TypeKind::Fn { constraints, params, ret } => {
-                write!(f, "Fn ")?;
+            TypeKind::Fn { constraints, params, ret, pure } => {
+                if *pure {
+                    write!(f, "Pu ")?;
+                } else {
+                    write!(f, "Fn ")?;
+                }
                 if constraints.len() > 0 {
                     write!(f, "<")?;
                     for (var, constraints) in constraints.iter() {

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -138,8 +138,8 @@ fn write_type<W: Write>(dest: &mut W, indent: u32, ty: Type) -> fmt::Result {
         TypeKind::Implied => unreachable!(),
         TypeKind::Resolved(ty) => write!(dest, "{}", ty),
         TypeKind::UserDefined(assignable) => write_type_assignable(dest, indent, assignable),
-        TypeKind::Fn { constraints, params, ret, pure } => {
-            if pure {
+        TypeKind::Fn { constraints, params, ret, is_pure } => {
+            if is_pure {
                 write!(dest, "pu")?;
             } else {
                 write!(dest, "fn")?;

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -138,8 +138,12 @@ fn write_type<W: Write>(dest: &mut W, indent: u32, ty: Type) -> fmt::Result {
         TypeKind::Implied => unreachable!(),
         TypeKind::Resolved(ty) => write!(dest, "{}", ty),
         TypeKind::UserDefined(assignable) => write_type_assignable(dest, indent, assignable),
-        TypeKind::Fn { constraints, params, ret } => {
-            write!(dest, "fn")?;
+        TypeKind::Fn { constraints, params, ret, pure } => {
+            if pure {
+                write!(dest, "pu")?;
+            } else {
+                write!(dest, "fn")?;
+            }
             if !constraints.is_empty() {
                 write!(dest, "<")?;
                 write_comma_separated!(dest, indent, write_constraint, constraints);

--- a/tests/bugs/iterator_chaining_607.sy
+++ b/tests/bugs/iterator_chaining_607.sy
@@ -1,4 +1,4 @@
 start :: fn do
     nums :: [1, 2, 3, 4, 5, 6, 7]
-    nums -> map(fn e do e*e end) -> for_each(print)
+    nums -> map(pu e do e*e end) -> for_each(print)
 end

--- a/tests/pure/impure_definition.sy
+++ b/tests/pure/impure_definition.sy
@@ -1,0 +1,2 @@
+start : fn -> void : pu do
+end

--- a/tests/pure/impure_std.sy
+++ b/tests/pure/impure_std.sy
@@ -1,0 +1,5 @@
+start :: pu do
+    a :: random'
+end
+
+// error: Cannot call impure functions from pure functions

--- a/tests/pure/interchangeability.sy
+++ b/tests/pure/interchangeability.sy
@@ -1,0 +1,10 @@
+a : [fn -> void] : [
+    fn do end,
+    pu do end,
+]
+
+start :: fn do
+    for_each(a, fn f: fn -> void do f() end)
+end
+
+// error:

--- a/tests/pure/pure_def_impure_impl.sy
+++ b/tests/pure/pure_def_impure_impl.sy
@@ -1,4 +1,4 @@
 start : pu -> void : fn do
 end
 
-// error:
+// error: Cannot use impure function implementations for pure function declarations

--- a/tests/pure/pure_def_impure_impl.sy
+++ b/tests/pure/pure_def_impure_impl.sy
@@ -1,0 +1,4 @@
+start : pu -> void : fn do
+end
+
+// error:

--- a/tests/pure/pure_list.sy
+++ b/tests/pure/pure_list.sy
@@ -1,0 +1,6 @@
+a : [fn -> void] : [
+    pu do end,
+]
+
+start :: fn do
+end

--- a/tests/pure/pure_std.sy
+++ b/tests/pure/pure_std.sy
@@ -1,0 +1,3 @@
+start :: pu do
+    a :: cos' 1.
+end

--- a/tests/sylt_std/as_char.sy
+++ b/tests/sylt_std/as_char.sy
@@ -1,5 +1,7 @@
+from maybe use (Maybe)
+
 start :: fn do
-    as_char("a") <=> 97
-    as_char(" ") <=> 32
-    as_char("!") <=> 33
+    as_char("a") <=> Maybe.Just 97
+    as_char(" ") <=> Maybe.Just 32
+    as_char("!") <=> Maybe.Just 33
 end

--- a/tests/sylt_std/fold.sy
+++ b/tests/sylt_std/fold.sy
@@ -1,5 +1,5 @@
 start :: fn do
-    sum :: [1, 2, 3, 4] -> fold' 0, fn a: int, b:int -> int a + b end
+    sum :: [1, 2, 3, 4] -> fold' 0, pu a: int, b:int -> int a + b end
     print' sum
     sum <=> 10
 end

--- a/tests/sylt_std/random.sy
+++ b/tests/sylt_std/random.sy
@@ -1,0 +1,12 @@
+start :: fn do
+    1 <=> randint' 1, 1
+
+    a :: random'
+    0. <= a and a <= 1. <=> true
+
+    b :: randint' 0, 5
+    0 <= b and b <= 5 <=> true
+
+    c :: randint' -10, -5
+    -10 <= c and c <= -5 <=> true
+end

--- a/tests/sylt_std/reduce.sy
+++ b/tests/sylt_std/reduce.sy
@@ -1,5 +1,5 @@
 start :: fn do
-    add :: fn a: *, b: * -> int a + b end
+    add :: pu a: *, b: * -> int a + b end
 
     sum :: reduce' [1, 2, 3, 4], add
     print' sum


### PR DESCRIPTION
Done:
- Add `Pure` constraint to inner type `pu`
- Marked appropriate functions in std/math as pure.

Todo:
- [x] Mark every appropriate std function as pure
- [x] Make sure the function body has the constraints that were defined in the definition. Right now the following should work, although it is incorrect.
      ```
      b := 2
      a : pu -> int : fn -> int
          b
      end
      ```