### PR TITLE
elif

### DIFF
--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -275,15 +275,14 @@ fn dependencies(ctx: &mut Context, expression: &Expression) -> BTreeSet<(String,
 
         If(branches) => branches
             .iter()
-            .map(|IfBranch { condition, body, span: _}| {
+            .map(|IfBranch { condition, body, span: _ }| {
                 [
                     condition
                         .as_ref()
                         .map(|cond| dependencies(ctx, &cond))
                         .unwrap_or_else(|| BTreeSet::new())
                         .clone(),
-                    body
-                        .iter()
+                    body.iter()
                         .map(|f| statement_dependencies(ctx, f))
                         .flatten()
                         .collect(),

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -337,29 +337,17 @@ impl<'a> IRCodeGen<'a> {
                         if let Some(cond) = condition {
                             let (expr, var) = self.expression(&cond, ctx);
                             let block = self.expression_block(out, body.clone(), ctx);
-                            [
-                                expr,
-                                vec![IR::If(var)],
-                                block,
-                                vec![IR::Else],
-                            ].concat()
+                            [expr, vec![IR::If(var)], block, vec![IR::Else]].concat()
                         } else {
                             let var = self.var();
                             let block = self.expression_block(out, body.clone(), ctx);
-                            [
-                                vec![IR::Bool(var, true),IR::If(var)],
-                                block,
-                            ].concat()
+                            [vec![IR::Bool(var, true), IR::If(var)], block].concat()
                         }
                     })
                     .flatten()
                     .collect::<Vec<_>>();
                 (
-                    [
-                        code,
-                        branches.iter().map(|_| IR::End).collect()
-                    ]
-                    .concat(),
+                    [code, branches.iter().map(|_| IR::End).collect()].concat(),
                     out,
                 )
             }

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -344,7 +344,12 @@ impl<'a> IRCodeGen<'a> {
                                 vec![IR::Else],
                             ].concat()
                         } else {
-                            self.expression_block(out, body.clone(), ctx)
+                            let var = self.var();
+                            let block = self.expression_block(out, body.clone(), ctx);
+                            [
+                                vec![IR::Bool(var, true),IR::If(var)],
+                                block,
+                            ].concat()
                         }
                     })
                     .flatten()
@@ -352,7 +357,7 @@ impl<'a> IRCodeGen<'a> {
                 (
                     [
                         code,
-                        branches.iter().skip(1).map(|_| IR::End).collect()
+                        branches.iter().map(|_| IR::End).collect()
                     ]
                     .concat(),
                     out,

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1170,13 +1170,13 @@ impl TypeChecker {
                         ret = self
                             .unify_option(*span, ctx, *branch_ret, ret)
                             .help_no_span(
-                                "The return from this block doesn't match the other branches"
+                                "The return from this block doesn't match the earlier branches"
                                     .into(),
                             )?;
                         value = self
                             .unify_option(*span, ctx, *branch_value, value)
                             .help_no_span(
-                                "The value from this block doesn't match the other branches".into(),
+                                "The value from this block doesn't match the earlier branches".into(),
                             )?;
                     }
                     value

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1131,31 +1131,56 @@ impl TypeChecker {
             }
 
             ExpressionKind::If(branches) => {
-                let tys = branches.iter_mut().map(|branch| {
-                    let condition_ret = if let Some(condition) = &mut branch.condition {
-                        let span = condition.span;
-                        let (ret, condition) = self.expression(condition, ctx)?;
-                        let boolean = self.push_type(Type::Bool);
-                        self.unify(span, ctx, boolean, condition)?;
-                        ret
-                    } else {
-                        None
-                    };
-                    let (block_ret, block_value) = self.expression_block(span, &mut branch.body, ctx)?;
-                    Ok((span, self.unify_option(span, ctx, condition_ret, block_ret)?, block_value))
-                }).collect::<TypeResult<Vec<_>>>()?;
+                let tys = branches
+                    .iter_mut()
+                    .map(|branch| {
+                        let condition_ret = if let Some(condition) = &mut branch.condition {
+                            let span = condition.span;
+                            let (ret, condition) = self.expression(condition, ctx)?;
+                            let boolean = self.push_type(Type::Bool);
+                            self.unify(span, ctx, boolean, condition)?;
+                            ret
+                        } else {
+                            None
+                        };
+                        let (block_ret, block_value) =
+                            self.expression_block(span, &mut branch.body, ctx)?;
+                        Ok((
+                            span,
+                            self.unify_option(span, ctx, condition_ret, block_ret)?,
+                            block_value,
+                        ))
+                    })
+                    .collect::<TypeResult<Vec<_>>>()?;
 
                 let mut ret = None;
-                let mut value = None;
-                for (span, branch_ret, branch_value) in tys.iter() {
-                    // TODO(ed): These are bad errors, they're easy to confuse. A better
-                    // formulation?
-                    ret = self.unify_option(*span, ctx, *branch_ret, ret)
-                        .help_no_span("The return from this block doesn't match the other branches".into())?;
-                    value = self.unify_option(*span, ctx, *branch_value, value)
-                        .help_no_span("The value from this block doesn't match the other branches".into())?;
-                }
-
+                let value = if branches
+                    .last()
+                    .map(|branch| branch.condition.is_some())
+                    .unwrap()
+                {
+                    // There isn't an else branch - so we can fall through.
+                    let void = self.push_type(Type::Void);
+                    Some(void)
+                } else {
+                    let mut value = None;
+                    for (span, branch_ret, branch_value) in tys.iter() {
+                        // TODO(ed): These are bad errors, they're easy to confuse. A better
+                        // formulation?
+                        ret = self
+                            .unify_option(*span, ctx, *branch_ret, ret)
+                            .help_no_span(
+                                "The return from this block doesn't match the other branches"
+                                    .into(),
+                            )?;
+                        value = self
+                            .unify_option(*span, ctx, *branch_value, value)
+                            .help_no_span(
+                                "The value from this block doesn't match the other branches".into(),
+                            )?;
+                    }
+                    value
+                };
                 with_ret(ret, value.unwrap_or_else(|| self.push_type(Type::Void)))
             }
 

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1176,7 +1176,8 @@ impl TypeChecker {
                         value = self
                             .unify_option(*span, ctx, *branch_value, value)
                             .help_no_span(
-                                "The value from this block doesn't match the earlier branches".into(),
+                                "The value from this block doesn't match the earlier branches"
+                                    .into(),
                             )?;
                     }
                     value

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -426,9 +426,7 @@ fn if_expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
     let (ctx, body) = block(expect!(ctx, T::Do, "Expected 'do' after if condition"))?;
     let condition = Some(condition);
 
-    let mut branches = vec![{
-        IfBranch { span, condition, body }
-    }];
+    let mut branches = vec![{ IfBranch { span, condition, body } }];
 
     let mut ctx = ctx;
     while matches!(ctx.token(), T::Elif) {
@@ -456,10 +454,7 @@ fn if_expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
         ctx
     };
 
-    Ok((
-        ctx,
-        Expression::new(span, ExpressionKind::If(branches)),
-    ))
+    Ok((ctx, Expression::new(span, ExpressionKind::If(branches))))
 }
 
 fn arrow_call<'t>(ctx: Context<'t>, lhs: &Expression) -> ParseResult<'t, Expression> {

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -942,6 +942,9 @@ mod test {
 
     test!(expression, if_expr: "if a do b else c end" => If { .. });
     test!(expression, if_expr_more: "1 + 1 + if a do b else 2 end + 2 + 2" => _);
+    test!(expression, if_elif_else_expr: "if a do b elif c do d else e end" => If { .. });
+    test!(expression, if_elif_expr: "if a do b elif c do d end" => If { .. });
+    test!(expression, if_only_if_expr: "if a do b end" => If { .. });
 
     test!(expression, fn_implicit_unknown_1: "fn a do 1 end" => _);
     test!(expression, fn_implicit_unknown_2: "fn a, b do 1 end" => _);

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -22,6 +22,13 @@ pub struct CaseBranch {
     pub body: Vec<Statement>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct IfBranch {
+    pub condition: Option<Expression>,
+    pub body: Vec<Statement>,
+    pub span: Span,
+}
+
 /// The different kinds of [Expression]s.
 ///
 /// Expressions are recursive and evaluate to some kind of value.
@@ -59,11 +66,7 @@ pub enum ExpressionKind {
     /// Makes your code go either here or there.
     ///
     /// `if <expression> <statement> [else <statement>]`.
-    If {
-        condition: Box<Expression>,
-        pass: Vec<Statement>,
-        fail: Vec<Statement>,
-    },
+    If(Vec<IfBranch>),
 
     /// A super branchy branch.
     ///
@@ -417,25 +420,45 @@ fn case_expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
 fn if_expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
     let span = ctx.span();
     let ctx = expect!(ctx, T::If, "Expected 'if' at start of if-expression");
-
     let (ctx, old_skip) = ctx.push_skip_newlines(true);
     let (ctx, condition) = expression(ctx)?;
     let ctx = ctx.pop_skip_newlines(old_skip);
+    let (ctx, body) = block(expect!(ctx, T::Do, "Expected 'do' after if condition"))?;
+    let condition = Some(condition);
 
-    let condition = Box::new(condition);
+    let mut branches = vec![{
+        IfBranch { span, condition, body }
+    }];
 
-    let (ctx, pass) = block(expect!(ctx, T::Do, "Expected 'do' after if condition"))?;
+    let mut ctx = ctx;
+    while matches!(ctx.token(), T::Elif) {
+        let (_ctx, branch) = {
+            let span = ctx.span();
+            let ctx = expect!(ctx, T::Elif);
+            let (ctx, old_skip) = ctx.push_skip_newlines(true);
+            let (ctx, condition) = expression(ctx)?;
+            let ctx = ctx.pop_skip_newlines(old_skip);
+            let (ctx, body) = block(expect!(ctx, T::Do, "Expected 'do' after elif condition"))?;
+            let condition = Some(condition);
+            (ctx, IfBranch { span, condition, body })
+        };
+        ctx = _ctx;
+        branches.push(branch);
+    }
 
-    let (ctx, fail) = if matches!(ctx.token(), T::Else) {
-        block(ctx.skip(1))?
+    let ctx = if matches!(ctx.token(), T::Else) {
+        let span = ctx.span();
+        let ctx = expect!(ctx, T::Else);
+        let (ctx, body) = block(ctx)?;
+        branches.push(IfBranch { span, condition: None, body });
+        ctx
     } else {
-        // No else so we insert an empty statement instead.
-        (ctx, Vec::new())
+        ctx
     };
 
     Ok((
         ctx,
-        Expression::new(span, ExpressionKind::If { condition, pass, fail }),
+        Expression::new(span, ExpressionKind::If(branches)),
     ))
 }
 
@@ -1025,20 +1048,20 @@ impl PrettyPrint for Expression {
                 }
                 return Ok(());
             }
-            EK::If { condition, pass, fail } => {
+            EK::If(branches) => {
+                write_indent(f, indent)?;
                 write!(f, "If\n")?;
-                write_indent(f, indent)?;
-                write!(f, "condition:\n")?;
-                condition.pretty_print(f, indent + 1)?;
-                write_indent(f, indent)?;
-                write!(f, "pass:\n")?;
-                for stmt in pass.iter() {
-                    stmt.pretty_print(f, indent + 1)?;
-                }
-                write_indent(f, indent)?;
-                write!(f, "fail:\n")?;
-                for stmt in fail.iter() {
-                    stmt.pretty_print(f, indent + 1)?;
+                for IfBranch { span: _, condition, body } in branches {
+                    write_indent(f, indent)?;
+                    if let Some(cond) = condition {
+                        write!(f, "Branch:\n")?;
+                        cond.pretty_print(f, indent + 1)?;
+                    } else {
+                        write!(f, "Else:")?;
+                    }
+                    for stmt in body.iter() {
+                        stmt.pretty_print(f, indent + 1)?;
+                    }
                 }
             }
             EK::Function { name, params, ret, body, pure } => {

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -250,7 +250,7 @@ pub fn block<'t>(ctx: Context<'t>) -> ParseResult<'t, Vec<Statement>> {
     let mut errs = Vec::new();
     let mut statements = Vec::new();
     // Parse multiple inner statements until } or EOF
-    while !matches!(ctx.token(), T::Else | T::End | T::EOF) {
+    while !matches!(ctx.token(), T::Else | T::Elif | T::End | T::EOF) {
         match statement(ctx) {
             Ok((_ctx, stmt)) => {
                 ctx = _ctx; // assign to outer

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -266,7 +266,7 @@ pub fn block<'t>(ctx: Context<'t>) -> ParseResult<'t, Vec<Statement>> {
 
     if errs.is_empty() {
         // Special case for chaining if-else-statements
-        if !matches!(ctx.token(), T::End | T::Else) {
+        if !matches!(ctx.token(), T::End | T::Else | T::Elif) {
             syntax_error!(ctx, "Expected 'end' after block");
         }
         let ctx = ctx.skip_if(T::End);
@@ -663,7 +663,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
 
     // Newline, RightBrace and Else can end a statment.
     // If a statement does not end, we only report it as a missing newline.
-    let ctx = if matches!(ctx.token(), T::End | T::Else) {
+    let ctx = if matches!(ctx.token(), T::End | T::Else | T::Elif) {
         ctx
     } else {
         expect!(ctx, T::Newline, "Expected newline to end statement")

--- a/sylt-tokenizer/src/token.rs
+++ b/sylt-tokenizer/src/token.rs
@@ -33,12 +33,14 @@ pub enum Token {
 
     #[token("if")]
     If,
+    #[token("elif")]
+    Elif,
+    #[token("else")]
+    Else,
     #[token("case")]
     Case,
     #[token("is")]
     Is,
-    #[token("else")]
-    Else,
     #[token("break")]
     Break,
     #[token("continue")]

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -308,23 +308,8 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
             write_expression(dest, indent, *expr)?;
             write!(dest, ")")?;
         }
-        ExpressionKind::If { condition, pass, fail } => {
-            write!(dest, "if ")?;
-            write_expression(dest, indent, *condition)?;
-            write!(dest, " do\n")?;
-            for stmt in pass.into_iter() {
-                write_statement(dest, indent + 1, stmt)?;
-            }
-
-            if fail.len() != 0 {
-                write_indents(dest, indent)?;
-                write!(dest, "else do\n")?;
-                for stmt in fail.into_iter() {
-                    write_statement(dest, indent + 1, stmt)?;
-                }
-            }
-            write_indents(dest, indent)?;
-            write!(dest, "end")?;
+        ExpressionKind::If(_) => {
+            panic!();
         }
         ExpressionKind::Case { to_match, branches, fall_through } => {
             write!(dest, "case ")?;

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -308,8 +308,28 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
             write_expression(dest, indent, *expr)?;
             write!(dest, ")")?;
         }
-        ExpressionKind::If(_) => {
-            panic!();
+        ExpressionKind::If(branches) => {
+            for (i, branch) in branches.into_iter().enumerate() {
+                match (branch.condition, i == 0) {
+                    (Some(expr), true) => {
+                        write!(dest, "if ")?;
+                        write_expression(dest, indent, expr)?;
+                        write!(dest, "do\n")?;
+                    }
+                    (None, true) => unreachable!("The parser should never return this"),
+                    (Some(expr), _) => {
+                        write!(dest, "elif ")?;
+                        write_expression(dest, indent, expr)?;
+                        write!(dest, "do\n")?;
+                    }
+                    (None, _) => {
+                        write!(dest, "else\n")?;
+                    }
+                }
+                for stmt in branch.body {
+                    write_statement(dest, indent + 1, stmt)?;
+                }
+            }
         }
         ExpressionKind::Case { to_match, branches, fall_through } => {
             write!(dest, "case ")?;

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -314,13 +314,13 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
                     (Some(expr), true) => {
                         write!(dest, "if ")?;
                         write_expression(dest, indent, expr)?;
-                        write!(dest, "do\n")?;
+                        write!(dest, " do\n")?;
                     }
                     (None, true) => unreachable!("The parser should never return this"),
                     (Some(expr), _) => {
                         write!(dest, "elif ")?;
                         write_expression(dest, indent, expr)?;
-                        write!(dest, "do\n")?;
+                        write!(dest, " do\n")?;
                     }
                     (None, _) => {
                         write!(dest, "else\n")?;
@@ -330,6 +330,8 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
                     write_statement(dest, indent + 1, stmt)?;
                 }
             }
+            write_indents(dest, indent)?;
+            write!(dest, "end\n")?;
         }
         ExpressionKind::Case { to_match, branches, fall_through } => {
             write!(dest, "case ")?;

--- a/tests/expression/if_expressions.sy
+++ b/tests/expression/if_expressions.sy
@@ -1,20 +1,20 @@
 grouping :: fn do
-    a := if true do 1 + 2 + 3 else do if false do -1 * 10 else do 2 + 2 end end
+    a := if true do 1 + 2 + 3 elif false do -1 * 10 else 2 + 2 end
     a <=> 6
-    b := if true do 1 + 2 + 3 else do if true do -1 * 10 else do 2 + 2 end end
+    b := if true do 1 + 2 + 3 elif true do -1 * 10 else 2 + 2 end
     b <=> 6
-    c := if false do 1 + 2 + 3 else do if true do -1 * 10 else do 2 + 2 end end
+    c := if false do 1 + 2 + 3 elif true do -1 * 10 else 2 + 2 end
     c <=> -10
-    d := if false do 1 + 2 + 3 else do if false do -1 * 10 else do 2 + 2 end end
+    d := if false do 1 + 2 + 3 elif false do -1 * 10 else 2 + 2 end
     d <=> 4
 end
 
 simple :: fn do
-    1 <=> if true do 1 else do 3 end
+    1 <=> if true do 1 else 3 end
 end
 
 expr :: fn do
-    2 <=> 1 + if true do 1 else do 3 end
+    2 <=> 1 + if true do 1 else 3 end
 end
 
 start :: fn do

--- a/tests/if_else/do_no_path.sy
+++ b/tests/if_else/do_no_path.sy
@@ -10,5 +10,3 @@ start :: fn do
     f' 3
     f' 0
 end
-
-// error: type isn't explicitly set to `void`

--- a/tests/if_else/do_no_path.sy
+++ b/tests/if_else/do_no_path.sy
@@ -1,0 +1,14 @@
+f :: fn a do
+    if a == 1 do
+        <!>
+    elif a == 2 do
+        <!>
+    end
+end
+
+start :: fn do
+    f' 3
+    f' 0
+end
+
+// error: type isn't explicitly set to `void`

--- a/tests/if_else/faulty_no_else_elif.sy
+++ b/tests/if_else/faulty_no_else_elif.sy
@@ -1,0 +1,12 @@
+f :: fn a ->
+    if a == 1 do
+        "a"
+    elif a == 2 do
+        "b"
+    end
+end
+
+start :: fn do
+end
+
+// error: type isn't explicitly set to `void`

--- a/tests/if_else/simple_elif.sy
+++ b/tests/if_else/simple_elif.sy
@@ -1,0 +1,17 @@
+f :: fn a ->
+    if a == 1 do
+        "a"
+    elif a == 2 do
+        "b"
+    else
+        "c"
+    end
+end
+
+start :: fn do
+    "a" <=> f' 1
+    "b" <=> f' 2
+    "c" <=> f' 3
+    "c" <=> f' 4
+    "c" <=> f' 0
+end


### PR DESCRIPTION
We now have `elif`, so if-else chains become a lot nicer. This also simplified both the typechecker and the parser. Which is nice.

The new syntax is more flexible and less verbose, something like this:

```
if true do
    aaa
elif false do
    bbb
else
    ccc
end
```

The typechecker now recognizes these statements are "void" statements:
```
if true do
    aaa
elif false do
    bbb
end
```
So if you don't cover all cases nothing is returned here. (Ofcourse it's only the typechecker, hehehe)
