### PR TITLE
Syntax for generics

### DIFF
--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -140,7 +140,7 @@ impl Compiler {
                         let other = include_to_namespace[file];
                         (Name::Namespace(other), ident.name.clone(), ident.span)
                     }
-                    Enum { name, .. }
+                    Enum { name: Identifier { name, ..}, .. }
                     | Blob { name, .. }
                     | Definition { ident: Identifier { name, .. }, .. }
                     | ExternalDefinition { ident: Identifier { name, .. }, .. } => {

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -2,7 +2,7 @@ use std::collections::{hash_map::Entry, HashMap};
 use std::io::Write;
 use sylt_common::error::Error;
 use sylt_common::FileOrLib;
-use sylt_parser::{Identifier, StatementKind, AST};
+use sylt_parser::{StatementKind, AST};
 
 mod dependency;
 mod intermediate;
@@ -140,11 +140,11 @@ impl Compiler {
                         let other = include_to_namespace[file];
                         (Name::Namespace(other), ident.name.clone(), ident.span)
                     }
-                    Enum { name: Identifier { name, ..}, .. }
+                    Enum { name, .. }
                     | Blob { name, .. }
-                    | Definition { ident: Identifier { name, .. }, .. }
-                    | ExternalDefinition { ident: Identifier { name, .. }, .. } => {
-                        (Name::Name, name.clone(), statement.span)
+                    | Definition { ident: name, .. }
+                    | ExternalDefinition { ident: name, .. } => {
+                        (Name::Name, name.name.clone(), name.span)
                     }
 
                     // Handled later since we need type information.

--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -221,18 +221,7 @@ fn statement_dependencies(ctx: &mut Context, statement: &Statement) -> BTreeSet<
 
         ExternalDefinition { ty, .. } => type_dependencies(ctx, ty),
 
-        Blob { name, fields: sub_types } => {
-            ctx.shadow(&name);
-            let namespace = ctx.namespace;
-            sub_types
-                .values()
-                .map(|t| type_dependencies(ctx, t))
-                .flatten()
-                .filter(|(n, s)| !(n == name && *s == namespace))
-                .collect()
-        }
-
-        Enum { name, variants: sub_types, .. } => {
+        Blob { name, fields: sub_types, .. } | Enum { name, variants: sub_types, .. } => {
             ctx.shadow(&name.name);
             let namespace = ctx.namespace;
             sub_types
@@ -456,7 +445,7 @@ pub(crate) fn initialization_order<'a>(
                     });
                 }
 
-                Blob { name, .. }
+                Blob { name: Identifier { name, .. }, .. }
                 | Enum { name: Identifier { name, .. }, .. }
                 | Use {
                     name: NameIdentifier::Implicit(Identifier { name, .. }),

--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -211,7 +211,7 @@ fn statement_dependencies(ctx: &mut Context, statement: &Statement) -> BTreeSet<
 
         ExternalDefinition { ty, .. } => type_dependencies(ctx, ty),
 
-        Blob { name, fields: sub_types } | Enum { name, variants: sub_types } => {
+        Blob { name, fields: sub_types } => {
             ctx.shadow(&name);
             let namespace = ctx.namespace;
             sub_types
@@ -219,6 +219,17 @@ fn statement_dependencies(ctx: &mut Context, statement: &Statement) -> BTreeSet<
                 .map(|t| type_dependencies(ctx, t))
                 .flatten()
                 .filter(|(n, s)| !(n == name && *s == namespace))
+                .collect()
+        }
+
+        Enum { name, variants: sub_types, .. } => {
+            ctx.shadow(&name.name);
+            let namespace = ctx.namespace;
+            sub_types
+                .values()
+                .map(|t| type_dependencies(ctx, t))
+                .flatten()
+                .filter(|(n, s)| !(n == &name.name && *s == namespace))
                 .collect()
         }
 
@@ -436,7 +447,7 @@ pub(crate) fn initialization_order<'a>(
                 }
 
                 Blob { name, .. }
-                | Enum { name, .. }
+                | Enum { name: Identifier { name, .. }, .. }
                 | Use {
                     name: NameIdentifier::Implicit(Identifier { name, .. }),
                     ..

--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -149,8 +149,18 @@ fn type_dependencies(ctx: &mut Context, ty: &ParserType) -> BTreeSet<(String, us
         Implied | Resolved(_) | Generic(_) => BTreeSet::new(),
 
         Grouping(ty) => type_dependencies(ctx, ty),
-        UserDefined(assignable) => type_assignable_dependencies(ctx, &assignable),
-
+        UserDefined(assignable, type_args) => [
+            type_args
+                .iter()
+                .map(|ty| type_dependencies(ctx, ty))
+                .flatten()
+                .collect(),
+            type_assignable_dependencies(ctx, &assignable),
+        ]
+        .iter()
+        .flatten()
+        .cloned()
+        .collect(),
         Fn { params, ret, .. } => params
             .iter()
             .chain([ret.as_ref()])

--- a/sylt-compiler/src/ty.rs
+++ b/sylt-compiler/src/ty.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use sylt_common::TyID;
+use sylt_parser::{Identifier, Span};
 
 #[derive(Debug, Clone)]
 pub enum Type {
@@ -21,6 +22,6 @@ pub enum Type {
     Set(TyID),
     Dict(TyID, TyID),
     Function(Vec<TyID>, TyID),
-    Blob(String, BTreeMap<String, TyID>, Vec<TyID>),
-    Enum(String, BTreeMap<String, TyID>, Vec<TyID>),
+    Blob(Identifier, BTreeMap<String, (Span, TyID)>, Vec<TyID>),
+    Enum(Identifier, BTreeMap<String, (Span, TyID)>, Vec<TyID>),
 }

--- a/sylt-compiler/src/ty.rs
+++ b/sylt-compiler/src/ty.rs
@@ -21,6 +21,6 @@ pub enum Type {
     Set(TyID),
     Dict(TyID, TyID),
     Function(Vec<TyID>, TyID),
-    Blob(String, BTreeMap<String, TyID>),
-    Enum(String, BTreeMap<String, TyID>),
+    Blob(String, BTreeMap<String, TyID>, Vec<TyID>),
+    Enum(String, BTreeMap<String, TyID>, Vec<TyID>),
 }

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -674,17 +674,20 @@ impl TypeChecker {
                     }
                 }
             }
-            StatementKind::Enum { name, variants } => {
+            StatementKind::Enum { name, variants, variables } => {
                 let enum_ty = self.push_type(Type::Unknown);
                 self.globals
-                    .insert((ctx.namespace, name.clone()), Name::Type(enum_ty));
+                    .insert((ctx.namespace, name.name.clone()), Name::Type(enum_ty));
                 let mut resolved_variants = BTreeMap::new();
                 let mut seen = HashMap::new();
+                for v in variables.iter() {
+                    seen.insert(v.name.clone(), self.push_type(Type::Unknown));
+                }
                 for (k, t) in variants.iter() {
                     resolved_variants
-                        .insert(k.clone(), self.inner_resolve_type(span, ctx, t, &mut seen)?);
+                        .insert(k.name.clone(), self.inner_resolve_type(span, ctx, t, &mut seen)?);
                 }
-                let ty = self.push_type(Type::Enum(name.clone(), resolved_variants));
+                let ty = self.push_type(Type::Enum(name.name.clone(), resolved_variants));
                 self.unify(span, ctx, ty, enum_ty)?;
             }
 

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -488,7 +488,12 @@ impl TypeChecker {
                                     "The type {} takes at most {} type arguments",
                                     name.name,
                                     sub.len()
-                                ).help(self, name.span, "Defined here".into());
+                                )
+                                .help(
+                                    self,
+                                    name.span,
+                                    "Defined here".into(),
+                                );
                             }
                             let var_ty = self.inner_resolve_type(var.span, ctx, var, seen)?;
                             self.unify(span, ctx, var_ty, sub[i])?;
@@ -497,7 +502,7 @@ impl TypeChecker {
 
                     // NOTE(ed): Is this going to hant me later?
                     // Gives better errors for recursive types - which are illegal.
-                    Type::Unknown => { }
+                    Type::Unknown => {}
 
                     _ => {
                         return err_type_error!(
@@ -1675,7 +1680,12 @@ impl TypeChecker {
                                 blob: blob_name.name.clone(),
                                 field: name.clone(),
                             }
-                        ).help(self, blob_name.span, "Defined here".to_string()),
+                        )
+                        .help(
+                            self,
+                            blob_name.span,
+                            "Defined here".to_string(),
+                        ),
                     },
                     _ => err_type_error!(
                         self,
@@ -1744,14 +1754,19 @@ impl TypeChecker {
 
                     Type::Enum(enum_name, variants, _) => match (variants.get(var), maybe_v_b) {
                         (Some(_), None) => Ok(()),
-                        (Some((_, v_a)), Some(v_b)) => self.unify(span, ctx, *v_a, *v_b).map(|_| ()),
-                        (None, _) => {
-                            err_type_error!(
-                                self,
-                                span,
-                                TypeError::UnknownVariant(enum_name.name, var.clone())
-                            ).help(self, enum_name.span, "Defined here".to_string())
+                        (Some((_, v_a)), Some(v_b)) => {
+                            self.unify(span, ctx, *v_a, *v_b).map(|_| ())
                         }
+                        (None, _) => err_type_error!(
+                            self,
+                            span,
+                            TypeError::UnknownVariant(enum_name.name, var.clone())
+                        )
+                        .help(
+                            self,
+                            enum_name.span,
+                            "Defined here".to_string(),
+                        ),
                     },
 
                     _ => err_type_error!(
@@ -1777,7 +1792,12 @@ impl TypeChecker {
                                 self,
                                 span,
                                 TypeError::MissingVariants(enum_name.name.clone(), missing)
-                            ).help(self, enum_name.span, "Defined here".to_string())
+                            )
+                            .help(
+                                self,
+                                enum_name.span,
+                                "Defined here".to_string(),
+                            )
                         } else {
                             let extra = enum_vars
                                 .iter()
@@ -1789,7 +1809,12 @@ impl TypeChecker {
                                     self,
                                     span,
                                     TypeError::ExtraVariants(enum_name.name.clone(), extra)
-                                ).help(self, enum_name.span, "Defined here".to_string())
+                                )
+                                .help(
+                                    self,
+                                    enum_name.span,
+                                    "Defined here".to_string(),
+                                )
                             } else {
                                 Ok(())
                             }
@@ -1969,7 +1994,12 @@ impl TypeChecker {
                                     blob: b_blob.name.clone(),
                                     field: a_field.clone()
                                 }
-                            ).help(self, b_blob.span, "Defined here".to_string());
+                            )
+                            .help(
+                                self,
+                                b_blob.span,
+                                "Defined here".to_string(),
+                            );
                         };
                     }
 
@@ -1984,11 +2014,19 @@ impl TypeChecker {
                                         blob: a_blob.name.clone(),
                                         field: b_field.clone()
                                     }
-                                ).help(self, a_blob.span, "Defined here".to_string());
+                                )
+                                .help(
+                                    self,
+                                    a_blob.span,
+                                    "Defined here".to_string(),
+                                );
                             }
                         };
-                        self.sub_unify(span, ctx, a_ty, *b_ty, seen)
-                            .help(self, *b_span, format!("While checking field .{}", b_field))?;
+                        self.sub_unify(span, ctx, a_ty, *b_ty, seen).help(
+                            self,
+                            *b_span,
+                            format!("While checking field .{}", b_field),
+                        )?;
                     }
                 }
 
@@ -1999,7 +2037,12 @@ impl TypeChecker {
                                 self,
                                 span,
                                 TypeError::UnknownVariant(b_name.name.clone(), a_var.clone())
-                            ).help(self, b_name.span, "Defined here".to_string());
+                            )
+                            .help(
+                                self,
+                                b_name.span,
+                                "Defined here".to_string(),
+                            );
                         }
                     }
                     for (b_var, (_b_span, b_ty)) in b_variants.iter() {
@@ -2010,11 +2053,19 @@ impl TypeChecker {
                                     self,
                                     span,
                                     TypeError::UnknownVariant(a_name.name.clone(), b_var.clone())
-                                ).help(self, a_name.span, "Defined here".to_string());
+                                )
+                                .help(
+                                    self,
+                                    a_name.span,
+                                    "Defined here".to_string(),
+                                );
                             }
                         };
-                        self.sub_unify(span, ctx, a_ty, *b_ty, seen)
-                            .help(self, a_span, format!("While checking variant {}", b_var))?;
+                        self.sub_unify(span, ctx, a_ty, *b_ty, seen).help(
+                            self,
+                            a_span,
+                            format!("While checking variant {}", b_var),
+                        )?;
                     }
                 }
 

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -489,6 +489,10 @@ impl TypeChecker {
                         }
                     }
 
+                    // NOTE(ed): Is this going to hant me later?
+                    // Gives better errors for recursive types - which are illegal.
+                    Type::Unknown => { }
+
                     _ => {
                         return err_type_error!(
                             self,

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -595,9 +595,6 @@ pub fn type_assignable<'t>(ctx: Context<'t>) -> ParseResult<'t, TypeAssignable> 
     ) -> ParseResult<'t, TypeAssignableKind> {
         let span = ctx.span();
         match ctx.token() {
-            T::LeftParen => {
-                todo!("Add in parsing for generics here!");
-            }
             T::Identifier(name) if is_capitalized(name) => {
                 let ctx = ctx.skip(1);
                 let ident = Identifier::new(span, name.clone());

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -404,9 +404,9 @@ impl<'a> Context<'a> {
 
 fn parse_sep_end_by<'t, Item>(
     ctx: Context<'t>,
-    sep: &dyn Fn(Context<'t>) -> ParseResult<'t, ()>,
-    end: &dyn Fn(Context<'t>) -> ParseResult<'t, bool>,
-    item: &dyn Fn(Context<'t>) -> ParseResult<'t, Item>,
+    sep: impl Fn(Context<'t>) -> ParseResult<'t, ()>,
+    end: impl Fn(Context<'t>) -> ParseResult<'t, bool>,
+    item: impl Fn(Context<'t>) -> ParseResult<'t, Item>,
 ) -> ParseResult<'t, Vec<Item>> {
     let (end_ctx, is_end) = end(ctx)?;
     if is_end {

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -464,6 +464,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
                     Ok((ctx, ()))
                 }
                 fn end<'t>(ctx: Context<'t>) -> ParseResult<'t, bool> {
+                    let ctx = skip_while!(ctx, T::Newline);
                     match ctx.token() {
                         // Done with variants.
                         T::End => Ok((ctx.skip(1), true)),

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -505,7 +505,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
                     };
                     Ok((ctx.skip_if(T::Comma), (variant, ty)))
                 }
-                parse_sep_end_by(ctx, &sep, &end, &item)?
+                parse_sep_end_by(ctx, sep, end, item)?
             };
 
             let mut variants = HashMap::new();

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -140,9 +140,7 @@ fn write_type<W: Write>(dest: &mut W, indent: u32, ty: Type) -> fmt::Result {
         TypeKind::UserDefined(assignable, args) => {
             write_type_assignable(dest, indent, assignable)?;
             write!(dest, "(")?;
-            for arg in args.into_iter() {
-                write_type(dest, indent, arg)?
-            }
+            write_comma_separated!(dest, indent, &|dest: &mut W, _, arg| write_type(dest, indent, arg), args);
             write!(dest, ")")
         }
         TypeKind::Fn { constraints, params, ret } => {
@@ -473,10 +471,10 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
         }
         StatementKind::Blob { name, fields, variables } => {
             write_indents(dest, indent)?;
-            write!(dest, "{} :: blob", name)?;
+            write!(dest, "{} :: blob", name.name)?;
             if variables.len() > 0 {
                 write!(dest, "(")?;
-                write_comma_separated!(dest, indent, &|dest: &mut W, _, var| write!(dest, "{}", var), variables);
+                write_comma_separated!(dest, indent, &|dest: &mut W, _, var: Identifier| write!(dest, "*{}", var.name), variables);
                 write!(dest, ")")?;
             }
             let fields_as_tuples = fields.into_iter().map(|(k, v)| (k.name, v)).collect();
@@ -487,7 +485,7 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             write!(dest, "{} :: enum", name.name)?;
             if variables.len() > 0 {
                 write!(dest, "(")?;
-                write_comma_separated!(dest, indent, &|dest: &mut W, _, var| write!(dest, "{}", var), variables);
+                write_comma_separated!(dest, indent, &|dest: &mut W, _, var: Identifier| write!(dest, "*{}", var.name), variables);
                 write!(dest, ")")?;
             }
             let variants_as_tuples = variants.into_iter().map(|(k, v)| (k.name, v)).collect();

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -90,7 +90,7 @@ fn write_enum_variants<W: Write>(
     mut variants: Vec<(String, Type)>,
 ) -> fmt::Result {
     match variants.len() {
-        0 => {}
+        0 => { write!(dest, "\n")?; }
         1 => {
             let (var, ty) = variants.pop().unwrap();
             write!(dest, " {} ", var)?;

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -471,10 +471,15 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             write_indents(dest, indent)?;
             write!(dest, "end")?
         }
-        StatementKind::Blob { name, fields } => {
+        StatementKind::Blob { name, fields, variables } => {
             write_indents(dest, indent)?;
             write!(dest, "{} :: blob", name)?;
-            let fields_as_tuples = fields.into_iter().collect();
+            if variables.len() > 0 {
+                write!(dest, "(")?;
+                write_comma_separated!(dest, indent, &|dest: &mut W, _, var| write!(dest, "{}", var), variables);
+                write!(dest, ")")?;
+            }
+            let fields_as_tuples = fields.into_iter().map(|(k, v)| (k.name, v)).collect();
             write_blob_fields(dest, indent + 1, fields_as_tuples, write_type)?;
         }
         StatementKind::Enum { name, variants, variables } => {

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -470,10 +470,11 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             let fields_as_tuples = fields.into_iter().collect();
             write_blob_fields(dest, indent + 1, fields_as_tuples, write_type)?;
         }
-        StatementKind::Enum { name, variants } => {
+        StatementKind::Enum { name, variants, .. } => {
+            todo!("Add in variables!");
             write_indents(dest, indent)?;
-            write!(dest, "{} :: enum", name)?;
-            let variants_as_tuples = variants.into_iter().collect();
+            write!(dest, "{} :: enum", name.name)?;
+            let variants_as_tuples = variants.into_iter().map(|(k, v)| (k.name, v)).collect();
             write_enum_variants(dest, indent + 1, variants_as_tuples)?;
         }
         StatementKind::Break => {

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -90,7 +90,9 @@ fn write_enum_variants<W: Write>(
     mut variants: Vec<(String, Type)>,
 ) -> fmt::Result {
     match variants.len() {
-        0 => { write!(dest, "\n")?; }
+        0 => {
+            write!(dest, "\n")?;
+        }
         1 => {
             let (var, ty) = variants.pop().unwrap();
             write!(dest, " {} ", var)?;
@@ -140,7 +142,12 @@ fn write_type<W: Write>(dest: &mut W, indent: u32, ty: Type) -> fmt::Result {
         TypeKind::UserDefined(assignable, args) => {
             write_type_assignable(dest, indent, assignable)?;
             write!(dest, "(")?;
-            write_comma_separated!(dest, indent, &|dest: &mut W, _, arg| write_type(dest, indent, arg), args);
+            write_comma_separated!(
+                dest,
+                indent,
+                &|dest: &mut W, _, arg| write_type(dest, indent, arg),
+                args
+            );
             write!(dest, ")")
         }
         TypeKind::Fn { constraints, params, ret, is_pure } => {
@@ -489,7 +496,12 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             write!(dest, "{} :: blob", name.name)?;
             if variables.len() > 0 {
                 write!(dest, "(")?;
-                write_comma_separated!(dest, indent, &|dest: &mut W, _, var: Identifier| write!(dest, "*{}", var.name), variables);
+                write_comma_separated!(
+                    dest,
+                    indent,
+                    &|dest: &mut W, _, var: Identifier| write!(dest, "*{}", var.name),
+                    variables
+                );
                 write!(dest, ")")?;
             }
             let fields_as_tuples = fields.into_iter().map(|(k, v)| (k.name, v)).collect();
@@ -500,7 +512,12 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             write!(dest, "{} :: enum", name.name)?;
             if variables.len() > 0 {
                 write!(dest, "(")?;
-                write_comma_separated!(dest, indent, &|dest: &mut W, _, var: Identifier| write!(dest, "*{}", var.name), variables);
+                write_comma_separated!(
+                    dest,
+                    indent,
+                    &|dest: &mut W, _, var: Identifier| write!(dest, "*{}", var.name),
+                    variables
+                );
                 write!(dest, ")")?;
             }
             let variants_as_tuples = variants.into_iter().map(|(k, v)| (k.name, v)).collect();

--- a/sylt/src/test.rs
+++ b/sylt/src/test.rs
@@ -263,5 +263,5 @@ fn program_tests() {
         "\n SUMMARY {}/{}      {} failed\n",
         num_passed, num_tests, num_failed
     );
-    assert!(failed.is_empty(), "Some tests failed!");
+    assert!(failed.is_empty() && formatter_failed.is_empty(), "Some tests failed!");
 }

--- a/sylt/src/test.rs
+++ b/sylt/src/test.rs
@@ -211,6 +211,7 @@ fn program_tests() {
     set_current_dir("../").unwrap();
     let tests = find_and_parse_tests(Path::new("tests/"));
     let mut failed = Vec::new();
+    let mut formatter_failed = Vec::new();
 
     writeln!(
         std::io::stdout().lock(),
@@ -234,7 +235,7 @@ fn program_tests() {
                 test,
             )
         {
-            failed.push(test);
+            formatter_failed.push(test);
             continue;
         }
     }
@@ -248,9 +249,16 @@ fn program_tests() {
         }
     }
 
+    if !formatter_failed.is_empty() {
+        eprintln!("\nFailed formatter tests:");
+        for fail in formatter_failed.iter() {
+            eprintln!(" {}", fail.path.to_str().unwrap());
+        }
+    }
+
     let num_tests = tests.len();
-    let num_failed = failed.len();
-    let num_passed = tests.len() - failed.len();
+    let num_failed = failed.len() + formatter_failed.len();
+    let num_passed = tests.len() - num_failed;
     eprintln!(
         "\n SUMMARY {}/{}      {} failed\n",
         num_passed, num_tests, num_failed

--- a/sylt/src/test.rs
+++ b/sylt/src/test.rs
@@ -263,5 +263,8 @@ fn program_tests() {
         "\n SUMMARY {}/{}      {} failed\n",
         num_passed, num_tests, num_failed
     );
-    assert!(failed.is_empty() && formatter_failed.is_empty(), "Some tests failed!");
+    assert!(
+        failed.is_empty() && formatter_failed.is_empty(),
+        "Some tests failed!"
+    );
 }

--- a/tests/blob/faulty_generic_blobs.sy
+++ b/tests/blob/faulty_generic_blobs.sy
@@ -1,4 +1,4 @@
-A :: blob {
+A :: blob(*a) {
     a: *a,
     b: *a,
 }

--- a/tests/enums/faulty_generics.sy
+++ b/tests/enums/faulty_generics.sy
@@ -1,6 +1,6 @@
-Maybe :: enum
-    Just *a,
-    Other *a,
+Maybe :: enum(*A)
+    Just *A,
+    Other *A,
     Nothing,
 end
 

--- a/tests/hm_typing/simple_generics.sy
+++ b/tests/hm_typing/simple_generics.sy
@@ -1,0 +1,14 @@
+A :: enum(*A, *B)
+    C *A,
+    D *B,
+end
+
+B :: blob(*A, *B) {
+    a: *A,
+    b: *B,
+}
+
+start :: fn do
+    a : A(int, int) : A.C 1
+    b : B(int) : B { a: 1, b: 2 }
+end


### PR DESCRIPTION
Added syntax for generics, this is now a valid program:

```
A :: enum(*A, *B)
    C *A,
    D *B,
end

B :: blob(*A, *A) {
    a: *A,
    b: *A,
}

start :: fn do
    a : A(int, int) : A.C 1
    b : B(int) : B { a: 1, b: 2 }
end
```

I also did some quite agressive changes to propogate spans in the type-checker.
We can now point a lot better att wierd generic errors. Maybe it shouldn't have
been in this PR, but I just happened to do it.

It's not quite done yet, but I'd rather get feedback now if something is extreemly off.
If you find a good test-case while testing add it somewhere so we can  add it to the test-suite. :D
