### PR TITLE
Clean up the compiler flags

### DIFF
--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -63,7 +63,12 @@ impl Compiler {
     }
 
     #[cfg_attr(timed, sylt_macro::timed("compile"))]
-    fn compile(&mut self, lua_file: &mut dyn Write, tree: AST, require: Option<&String>) -> Result<(), Vec<Error>> {
+    fn compile(
+        &mut self,
+        lua_file: &mut dyn Write,
+        tree: AST,
+        require: Option<&String>,
+    ) -> Result<(), Vec<Error>> {
         assert!(!tree.modules.is_empty(), "Cannot compile an empty program");
 
         self.extract_namespaces(&tree);
@@ -133,6 +138,10 @@ impl Compiler {
     }
 }
 
-pub fn compile(lua_file: &mut dyn Write, prog: AST, require: Option<&String>) -> Result<(), Vec<Error>> {
+pub fn compile(
+    lua_file: &mut dyn Write,
+    prog: AST,
+    require: Option<&String>,
+) -> Result<(), Vec<Error>> {
     Compiler::new().compile(lua_file, prog, require)
 }

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -63,7 +63,7 @@ impl Compiler {
     }
 
     #[cfg_attr(timed, sylt_macro::timed("compile"))]
-    fn compile(&mut self, lua_file: &mut dyn Write, tree: AST) -> Result<(), Vec<Error>> {
+    fn compile(&mut self, lua_file: &mut dyn Write, tree: AST, require: Option<&String>) -> Result<(), Vec<Error>> {
         assert!(!tree.modules.is_empty(), "Cannot compile an empty program");
 
         self.extract_namespaces(&tree);
@@ -108,7 +108,7 @@ impl Compiler {
         let ir = intermediate::compile(&typechecker, &statements);
         let usage_count = intermediate::count_usages(&ir);
 
-        lua::generate(&ir, &usage_count, lua_file);
+        lua::generate(&ir, &usage_count, lua_file, require);
 
         Ok(())
     }
@@ -133,6 +133,6 @@ impl Compiler {
     }
 }
 
-pub fn compile(lua_file: &mut dyn Write, prog: AST) -> Result<(), Vec<Error>> {
-    Compiler::new().compile(lua_file, prog)
+pub fn compile(lua_file: &mut dyn Write, prog: AST, require: Option<&String>) -> Result<(), Vec<Error>> {
+    Compiler::new().compile(lua_file, prog, require)
 }

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -81,8 +81,11 @@ impl<'a, 'b> Generator<'a, 'b> {
         self.lut.insert(var, value);
     }
 
-    pub fn generate(&mut self, ir: &Vec<IR>) {
+    pub fn generate(&mut self, ir: &Vec<IR>, require: Option<&String>) {
         write!(self.out, include_str!("preamble.lua"));
+        if let Some(file) = require {
+            write!(self.out, "require \"{}\"", file.strip_suffix(".lua").unwrap_or(file));
+        }
 
         let mut depth = 0;
         for instruction in ir.iter() {
@@ -299,6 +302,6 @@ impl<'a, 'b> Generator<'a, 'b> {
 }
 
 #[cfg_attr(timed, sylt_macro::timed("lua::generate"))]
-pub fn generate(ir: &Vec<IR>, usage_count: &HashMap<Var, usize>, out: &mut dyn Write) {
-    Generator::new(usage_count, out).generate(ir);
+pub fn generate(ir: &Vec<IR>, usage_count: &HashMap<Var, usize>, out: &mut dyn Write, require: Option<&String>) {
+    Generator::new(usage_count, out).generate(ir, require);
 }

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -84,7 +84,11 @@ impl<'a, 'b> Generator<'a, 'b> {
     pub fn generate(&mut self, ir: &Vec<IR>, require: Option<&String>) {
         write!(self.out, include_str!("preamble.lua"));
         if let Some(file) = require {
-            write!(self.out, "require \"{}\"", file.strip_suffix(".lua").unwrap_or(file));
+            write!(
+                self.out,
+                "require \"{}\"",
+                file.strip_suffix(".lua").unwrap_or(file)
+            );
         }
 
         let mut depth = 0;
@@ -302,6 +306,11 @@ impl<'a, 'b> Generator<'a, 'b> {
 }
 
 #[cfg_attr(timed, sylt_macro::timed("lua::generate"))]
-pub fn generate(ir: &Vec<IR>, usage_count: &HashMap<Var, usize>, out: &mut dyn Write, require: Option<&String>) {
+pub fn generate(
+    ir: &Vec<IR>,
+    usage_count: &HashMap<Var, usize>,
+    out: &mut dyn Write,
+    require: Option<&String>,
+) {
     Generator::new(usage_count, out).generate(ir, require);
 }

--- a/sylt/src/lib.rs
+++ b/sylt/src/lib.rs
@@ -23,11 +23,11 @@ where
     R: Fn(&Path) -> Result<String, Error>,
 {
     let file = PathBuf::from(args.args.first().expect("No file to run"));
-    let tree = sylt_parser::tree(&file, reader, true)?;
+    let tree = sylt_parser::tree(&file, reader, !args.no_std)?;
     if args.dump_tree {
         println!("{}", tree);
     }
-    sylt_compiler::compile(write_file, tree)
+    sylt_compiler::compile(write_file, tree, args.require.as_ref())
 }
 
 // TODO(ed): This name isn't true anymore - since it can compile
@@ -97,14 +97,19 @@ pub struct Args {
     )]
     pub output: Option<String>,
 
+    #[options(
+        long = "require",
+        short = "r",
+        meta = "FILE",
+        help = "A lua file to require, usefull for external code. The argument is placed directly in a \"require\""
+    )]
+    pub require: Option<String>,
+
+    #[options(long = "no-std", help = "Don't include the sylt-std files")]
+    pub no_std: bool,
+
     #[options(short = "v", no_long, count, help = "Increase verbosity (max 2)")]
     pub verbosity: u32,
-
-    #[options(
-        long = "format",
-        help = "Format the file and write the result to stdout"
-    )]
-    pub format: bool,
 
     #[options(help = "Print this help")]
     pub help: bool,


### PR DESCRIPTION
Add the `--no-std` flag, usefull when debugging imports and the typechecker since it dramatically reduces the size of the program.
Also added the `--require/-r` flag, which lets you require a lua file. This is usefull if you want to inject some lua code (like a library written in lua). The reasoning for having only one is so you collect all the imports in one file. I think it makes the most sense.
